### PR TITLE
fix: resolve CI type-check failures

### DIFF
--- a/__tests__/view/repeat.test.ts
+++ b/__tests__/view/repeat.test.ts
@@ -54,7 +54,7 @@ describe("repeat() keyed list reconciliation", () => {
         ],
       });
       const view = html`<ul data-testid="${TEST_ID}">
-        ${repeat(
+        ${repeat<{ id: number; text: string }>(
           vm.$items,
           i => i.id,
           i => html`<li>${i.text}</li>`
@@ -72,7 +72,7 @@ describe("repeat() keyed list reconciliation", () => {
         items: [{ id: 1, text: "First" }],
       });
       const view = html`<ul data-testid="${TEST_ID}">
-        ${repeat(
+        ${repeat<{ id: number; text: string }>(
           vm.$items,
           i => i.id,
           i => html`<li>${i.text}</li>`
@@ -100,7 +100,7 @@ describe("repeat() keyed list reconciliation", () => {
         ],
       });
       const view = html`<ul data-testid="${TEST_ID}">
-        ${repeat(
+        ${repeat<{ id: number; text: string }>(
           vm.$items,
           i => i.id,
           i => html`<li>${i.text}</li>`
@@ -130,7 +130,7 @@ describe("repeat() keyed list reconciliation", () => {
         ],
       });
       const view = html`<ul data-testid="${TEST_ID}">
-        ${repeat(
+        ${repeat<{ id: number; text: string }>(
           vm.$items,
           i => i.id,
           i => html`<li>${i.text}</li>`
@@ -170,7 +170,7 @@ describe("repeat() keyed list reconciliation", () => {
         ],
       });
       const view = html`<ul data-testid="${TEST_ID}">
-        ${repeat(
+        ${repeat<{ id: number; text: string }>(
           vm.$items,
           i => i.id,
           i => html`<li>${i.text}</li>`
@@ -204,7 +204,7 @@ describe("repeat() keyed list reconciliation", () => {
         ],
       });
       const view = html`<ul data-testid="${TEST_ID}">
-        ${repeat(
+        ${repeat<{ id: number; text: string }>(
           vm.$items,
           i => i.id,
           i => html`<li>${i.text}</li>`
@@ -235,7 +235,7 @@ describe("repeat() keyed list reconciliation", () => {
         ],
       });
       const view = html`<ul data-testid="${TEST_ID}">
-        ${repeat(
+        ${repeat<{ id: number; text: string }>(
           vm.$items,
           i => i.id,
           i => html`<li>${i.text}</li>`
@@ -255,7 +255,7 @@ describe("repeat() keyed list reconciliation", () => {
         items: [{ id: 1, text: "First" }],
       });
       const view = html`<ul data-testid="${TEST_ID}">
-        ${repeat(
+        ${repeat<{ id: number; text: string }>(
           vm.$items,
           i => i.id,
           i => html`<li>${i.text}</li>`
@@ -280,7 +280,7 @@ describe("repeat() keyed list reconciliation", () => {
         ],
       });
       const view = html`<ul data-testid="${TEST_ID}">
-        ${repeat(
+        ${repeat<{ id: number; text: string }>(
           vm.$items,
           i => i.id,
           i => html`<li>${i.text}</li>`

--- a/src/schema/schemaPropFactory.ts
+++ b/src/schema/schemaPropFactory.ts
@@ -188,10 +188,7 @@ export class SchemaProp {
     const parent = node.parentElement;
     return (newValue: SchemaPropValue): void => {
       if (node instanceof Attr) {
-        node.value = node.value.replace(
-          String(oldValue),
-          String(newValue)
-        );
+        node.value = node.value.replace(String(oldValue), String(newValue));
       } else if (Array.isArray(newValue)) {
         parent?.replaceChildren(...(newValue as (string | Node)[]));
       } else {

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -9,7 +9,7 @@ export type SchemaPropValue =
   | SchemaPropValue[];
 export type SchemaPropNotify = (newValue: SchemaPropValue) => void;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type SchemaPropExpression = (value: any) => SchemaPropValue;
+export type SchemaPropExpression = (value: any) => any;
 
 // Array method types for schema properties
 export type SchemaArrayMethods<T> = Pick<


### PR DESCRIPTION
## Summary

- Relaxes `SchemaPropExpression` return type from `SchemaPropValue` to `any` so `compute()` can accept expressions that return function values (e.g. reactive event handlers used in `@click`)
- Adds explicit `<{ id: number; text: string }>` type parameters to the 9 `repeat(vm.$items, ...)` calls in `repeat.test.ts` — `SchemaProp.value` is typed as `any`, which causes `any & T[]` to collapse to `any` in the intersection, breaking generic inference for `T`

## Test plan

- [x] `npm run type-check` passes with no errors
- [x] `npm run test` — 209 tests pass, 19 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)