### PR TITLE
fix: resolve 4 ESLint errors failing CI lint step

### DIFF
--- a/__tests__/reactivity/signal.test.ts
+++ b/__tests__/reactivity/signal.test.ts
@@ -1,4 +1,5 @@
 import { signal, computed, effect, batch, untracked } from "../../src/reactivity";
+import { useViewModel } from "../../src";
 
 const flush = () => new Promise<void>(resolve => queueMicrotask(resolve));
 
@@ -249,8 +250,6 @@ describe("Signal Primitives", () => {
 
   describe("Fine-grained dependency tracking in ViewModel", () => {
     it("should only re-evaluate computed props that depend on the changed signal", () => {
-      const { useViewModel } = require("../../src");
-
       let nameComputeCount = 0;
       let ageComputeCount = 0;
 

--- a/src/useViewModel/useViewModel.ts
+++ b/src/useViewModel/useViewModel.ts
@@ -58,17 +58,19 @@ export const useViewModel = function <TModel extends Model>(
   model = { ...model };
 
   // Identify computed properties (functions in the model)
-  const computedFunctions = new Map<string, Function>();
+  const computedFunctions = new Map<string, (vm: unknown) => unknown>();
   for (const key in model) {
     const value = model[key];
     if (typeof value === "function") {
-      computedFunctions.set(key, value);
+      computedFunctions.set(key, value as (vm: unknown) => unknown);
       delete model[key];
     }
   }
 
-  // Create proxy reference for computed functions to access
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // Create proxy reference for computed functions to access.
+  // Must be `let` — assigned after the proxy is created to break the circular
+  // reference between `traps` (which captures proxyRef) and `proxy` itself.
+  // eslint-disable-next-line prefer-const, @typescript-eslint/no-explicit-any
   let proxyRef: any;
 
   // Signal-backed computed properties: each creates a ReadonlySignal that

--- a/src/view/external/when.ts
+++ b/src/view/external/when.ts
@@ -35,7 +35,7 @@ export const when = (
   const empty = (): Node => document.createTextNode("");
 
   const getNode = (value: unknown): Node =>
-    Boolean(value) ? truthy() : (falsy?.() ?? empty());
+    value ? truthy() : (falsy?.() ?? empty());
 
   // Static condition — return the correct node directly, no reactive overhead
   if (typeof condition === "boolean") {


### PR DESCRIPTION
## Summary

Fixes the 4 lint **errors** (not warnings) that were causing the CI `Run linting` step to exit non-zero:

- **`signal.test.ts`** — converted inline `require()` to a top-level `import` (`@typescript-eslint/no-var-requires`)
- **`useViewModel.ts`** — replaced banned `Function` type with `(vm: unknown) => unknown` (`@typescript-eslint/ban-types`); added `eslint-disable` for `prefer-const` on `proxyRef` (the `let` is intentional — it's assigned after the proxy is created to break a circular reference between `traps` and `proxy`)
- **`when.ts`** — removed redundant `Boolean()` wrapper in ternary; bare `value` is sufficient since the ternary already coerces to boolean (`no-extra-boolean-cast`)

## Test plan

- [x] `npm run lint` — 0 errors (49 warnings unchanged)
- [x] `npm run type-check` — clean
- [x] `npm run test` — 209 tests pass, 19 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)