### PR TITLE
feat: add store() core — Phase 2 of deep-reactivity initiative

### DIFF
--- a/__tests__/reactivity/store.test.ts
+++ b/__tests__/reactivity/store.test.ts
@@ -1,0 +1,456 @@
+import {
+  store,
+  markRaw,
+  isStore,
+  unwrap,
+  effect,
+  computed,
+  batch,
+  untracked,
+} from "../../src/reactivity";
+
+const flush = () => new Promise<void>(resolve => queueMicrotask(resolve));
+
+describe("store() — Phase 2 core", () => {
+  describe("basic shape", () => {
+    it("creates a store that reads and writes like a plain object", () => {
+      const s = store({ count: 0, name: "Alice" });
+      expect(s.count).toBe(0);
+      expect(s.name).toBe("Alice");
+      s.count = 5;
+      expect(s.count).toBe(5);
+    });
+
+    it("is structurally T (you can pass it where T is expected)", () => {
+      interface User {
+        name: string;
+        age: number;
+      }
+      const s = store<User>({ name: "Alice", age: 30 });
+      // Should type-check as User:
+      const u: User = s;
+      expect(u.name).toBe("Alice");
+    });
+
+    it("returns the same proxy for the same input (idempotent)", () => {
+      const raw = { x: 1 };
+      const a = store(raw);
+      const b = store(raw);
+      expect(a).toBe(b);
+    });
+
+    it("returns the store itself when called on an existing store", () => {
+      const a = store({ x: 1 });
+      const b = store(a);
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("identity caching", () => {
+    it("nested object access returns the same proxy across reads", () => {
+      const s = store({ user: { name: "Alice" } });
+      expect(s.user).toBe(s.user);
+    });
+
+    it("does not break referential equality of read-back values", () => {
+      const s = store({ user: { name: "Alice" } });
+      const u1 = s.user;
+      const u2 = s.user;
+      expect(u1).toBe(u2);
+    });
+
+    it("returns a fresh proxy after a subtree is replaced", () => {
+      const s = store({ user: { name: "Alice" } as { name: string } });
+      const before = s.user;
+      s.user = { name: "Bob" };
+      const after = s.user;
+      expect(after).not.toBe(before);
+      expect(after.name).toBe("Bob");
+    });
+  });
+
+  describe("path-level granularity", () => {
+    it("writing one path does not wake subscribers of a sibling path", () => {
+      const s = store({ user: { name: "Alice", age: 30 } });
+      let nameRuns = 0;
+      let ageRuns = 0;
+      effect(() => {
+        s.user.name;
+        nameRuns++;
+      });
+      effect(() => {
+        s.user.age;
+        ageRuns++;
+      });
+      expect(nameRuns).toBe(1);
+      expect(ageRuns).toBe(1);
+
+      s.user.name = "Bob";
+      return flush().then(() => {
+        expect(nameRuns).toBe(2);
+        expect(ageRuns).toBe(1);
+      });
+    });
+
+    it("setting a property to its current value is a no-op", () => {
+      const s = store({ x: 1 });
+      let runs = 0;
+      effect(() => {
+        s.x;
+        runs++;
+      });
+      expect(runs).toBe(1);
+      s.x = 1;
+      return flush().then(() => {
+        expect(runs).toBe(1);
+      });
+    });
+
+    it("writes to a nested path notify only that path's subscribers", () => {
+      const s = store({ a: { b: { c: 0 } } });
+      let runs = 0;
+      effect(() => {
+        s.a.b.c;
+        runs++;
+      });
+      expect(runs).toBe(1);
+      s.a.b.c = 1;
+      return flush().then(() => {
+        expect(runs).toBe(2);
+      });
+    });
+
+    it("subtree-identity subscriber fires only when the subtree is replaced", () => {
+      const s = store({ user: { name: "Alice" } as { name: string } });
+      let runs = 0;
+      effect(() => {
+        s.user; // subscribe to user-identity
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      // Mutating inside the subtree does not change subtree identity.
+      s.user.name = "Bob";
+      return flush()
+        .then(() => {
+          expect(runs).toBe(1);
+
+          // Replacing the subtree changes identity, fires the subscriber.
+          s.user = { name: "Carol" };
+          return flush();
+        })
+        .then(() => {
+          expect(runs).toBe(2);
+        });
+    });
+  });
+
+  describe("reads are free outside reactive contexts", () => {
+    it("plain reads do not allocate metadata on the raw object", () => {
+      const raw = { user: { name: "Alice" } };
+      const s = store(raw);
+      // Force several reads outside any tracked context:
+      void s.user.name;
+      void s.user.name;
+      void s.user;
+
+      // No tracking ⇒ no $NODE allocation on the raw root, and no $NODE on
+      // the nested user object. We assert by Object.getOwnPropertySymbols.
+      const rootSymbols = Object.getOwnPropertySymbols(raw);
+      const userSymbols = Object.getOwnPropertySymbols(raw.user);
+      // $PROXY may be present (identity cache), but $NODE must NOT be.
+      const hasNodeSymbol = (target: object) =>
+        Object.getOwnPropertySymbols(target).some(
+          s => s.description === "marjoram.node"
+        );
+      expect(hasNodeSymbol(raw)).toBe(false);
+      expect(hasNodeSymbol(raw.user)).toBe(false);
+      // Sanity — at least one read happened on each, so $PROXY may exist
+      expect(rootSymbols.length + userSymbols.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("a tracked read allocates a single SignalNode for that path", () => {
+      const raw = { x: 1 };
+      const s = store(raw);
+      effect(() => {
+        s.x;
+      });
+      const symbols = Object.getOwnPropertySymbols(raw);
+      const nodeSymbol = symbols.find(
+        sym => sym.description === "marjoram.node"
+      );
+      expect(nodeSymbol).toBeDefined();
+      const nodes = (raw as unknown as Record<symbol, Record<string, unknown>>)[
+        nodeSymbol!
+      ];
+      expect(Object.keys(nodes)).toContain("x");
+    });
+  });
+
+  describe("computed integration", () => {
+    it("computed values derived from store paths update on write", () => {
+      const s = store({ a: 1, b: 2 });
+      const sum = computed(() => s.a + s.b);
+      expect(sum()).toBe(3);
+      s.a = 10;
+      expect(sum()).toBe(12);
+      s.b = 20;
+      expect(sum()).toBe(30);
+    });
+
+    it("computed reads of unrelated paths do not invalidate", () => {
+      const s = store({ a: 1, b: 2 });
+      let derivations = 0;
+      const doubled = computed(() => {
+        derivations++;
+        return s.a * 2;
+      });
+      expect(doubled()).toBe(2);
+      expect(derivations).toBe(1);
+
+      // Writing to `b` should not invalidate doubled (depends only on `a`).
+      s.b = 999;
+      expect(doubled()).toBe(2);
+      expect(derivations).toBe(1);
+
+      // Writing to `a` should invalidate.
+      s.a = 5;
+      expect(doubled()).toBe(10);
+      expect(derivations).toBe(2);
+    });
+  });
+
+  describe("batch integration", () => {
+    it("multiple writes inside batch() produce one effect re-run", async () => {
+      const s = store({ a: 1, b: 2 });
+      let runs = 0;
+      effect(() => {
+        s.a;
+        s.b;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      batch(() => {
+        s.a = 10;
+        s.b = 20;
+      });
+
+      await flush();
+      expect(runs).toBe(2); // not 3
+    });
+  });
+
+  describe("untracked integration", () => {
+    it("reads inside untracked() do not create subscriptions", async () => {
+      const s = store({ a: 1 });
+      let runs = 0;
+      effect(() => {
+        untracked(() => s.a);
+        runs++;
+      });
+      expect(runs).toBe(1);
+      s.a = 999;
+      await flush();
+      expect(runs).toBe(1); // not 2 — untracked
+    });
+  });
+
+  describe("key add / delete", () => {
+    it("adding a new key notifies iteration subscribers", async () => {
+      interface Bag {
+        [k: string]: unknown;
+      }
+      const s = store<Bag>({ x: 1 });
+      let keys: string[] = [];
+      let runs = 0;
+      effect(() => {
+        keys = Object.keys(s);
+        runs++;
+      });
+      expect(runs).toBe(1);
+      expect(keys).toEqual(["x"]);
+
+      s.y = 2;
+      await flush();
+      expect(runs).toBe(2);
+      expect(keys).toContain("y");
+    });
+
+    it("deleting a key notifies iteration subscribers", async () => {
+      interface Bag {
+        x?: number;
+        y?: number;
+      }
+      const s = store<Bag>({ x: 1, y: 2 });
+      let keys: string[] = [];
+      let runs = 0;
+      effect(() => {
+        keys = Object.keys(s);
+        runs++;
+      });
+      expect(runs).toBe(1);
+      expect(keys.length).toBe(2);
+
+      delete s.y;
+      await flush();
+      expect(runs).toBe(2);
+      expect(keys).toEqual(["x"]);
+    });
+
+    it("setting an existing key to a new value does NOT notify iteration subscribers", async () => {
+      const s = store({ x: 1, y: 2 });
+      let runs = 0;
+      effect(() => {
+        Object.keys(s);
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      s.x = 5; // existing key, not a new key
+      await flush();
+      expect(runs).toBe(1);
+    });
+  });
+
+  describe("markRaw", () => {
+    it("prevents an object from being proxied inside a store", () => {
+      const raw = { nested: { secret: 42 } };
+      markRaw(raw);
+      const s = store({ payload: raw });
+      // The raw object passes through identity-preserved:
+      expect(s.payload).toBe(raw);
+      // It is not a store:
+      expect(isStore(s.payload)).toBe(false);
+    });
+
+    it("mutations to a markRaw'd object do not notify the store", async () => {
+      const raw = { value: 1 };
+      markRaw(raw);
+      const s = store({ payload: raw });
+      let runs = 0;
+      effect(() => {
+        s.payload.value;
+        runs++;
+      });
+      expect(runs).toBe(1);
+      raw.value = 2;
+      await flush();
+      expect(runs).toBe(1); // not 2 — raw mutations bypass reactivity
+    });
+  });
+
+  describe("isStore", () => {
+    it("returns true for stores", () => {
+      const s = store({ x: 1 });
+      expect(isStore(s)).toBe(true);
+    });
+
+    it("returns true for nested store accesses", () => {
+      const s = store({ user: { name: "Alice" } });
+      expect(isStore(s.user)).toBe(true);
+    });
+
+    it("returns false for plain objects", () => {
+      expect(isStore({ x: 1 })).toBe(false);
+    });
+
+    it("returns false for primitives, null, undefined", () => {
+      expect(isStore(null)).toBe(false);
+      expect(isStore(undefined)).toBe(false);
+      expect(isStore(42)).toBe(false);
+      expect(isStore("string")).toBe(false);
+      expect(isStore(true)).toBe(false);
+    });
+
+    it("returns false for class instances", () => {
+      class C {
+        x = 1;
+      }
+      expect(isStore(new C())).toBe(false);
+    });
+  });
+
+  describe("unwrap", () => {
+    it("returns the underlying raw object", () => {
+      const raw = { x: 1, nested: { y: 2 } };
+      const s = store(raw);
+      expect(unwrap(s)).toBe(raw);
+    });
+
+    it("returns the value as-is when given a non-store", () => {
+      const plain = { x: 1 };
+      expect(unwrap(plain)).toBe(plain);
+    });
+
+    it("mutations to unwrapped raw do NOT notify subscribers", async () => {
+      const raw = { x: 1 };
+      const s = store(raw);
+      let runs = 0;
+      effect(() => {
+        s.x;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      // Mutate via raw, bypassing the proxy.
+      const r = unwrap(s);
+      r.x = 999;
+      await flush();
+      expect(runs).toBe(1); // intentional — documented behavior
+    });
+  });
+
+  describe("boundary rules — built-ins pass through", () => {
+    it("Date instances are not proxied", () => {
+      const d = new Date();
+      const s = store({ when: d });
+      expect(s.when).toBe(d); // identity preserved
+      expect(isStore(s.when)).toBe(false);
+    });
+
+    it("class instances are not proxied", () => {
+      class Widget {
+        name = "x";
+      }
+      const w = new Widget();
+      const s = store({ w });
+      expect(s.w).toBe(w);
+      expect(isStore(s.w)).toBe(false);
+    });
+
+    it("frozen objects pass through unproxied", () => {
+      const frozen = Object.freeze({ x: 1 });
+      const s = store({ payload: frozen });
+      expect(s.payload).toBe(frozen);
+      expect(isStore(s.payload)).toBe(false);
+    });
+
+    it("Map and Set pass through unproxied", () => {
+      const m = new Map();
+      const st = new Set();
+      const s = store({ m, st });
+      expect(s.m).toBe(m);
+      expect(s.st).toBe(st);
+    });
+  });
+
+  describe("does not break existing primitives", () => {
+    it("signal, computed, effect, batch, untracked still work unchanged", async () => {
+      // This test exists to lock the non-breaking-change rule for Phase 2.
+      // If it ever fails after edits to store.ts or signal.ts, the change
+      // probably regressed existing behavior.
+      const { signal: sig } = await import("../../src/reactivity");
+      const a = sig(1);
+      let runs = 0;
+      effect(() => {
+        a();
+        runs++;
+      });
+      expect(runs).toBe(1);
+      a.set(2);
+      await flush();
+      expect(runs).toBe(2);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,6 @@ export { createWidget } from "./widget/createWidget";
 
 export { signal, computed, effect, batch, untracked } from "./reactivity";
 export type { Signal, ReadonlySignal } from "./reactivity";
+
+export { store, markRaw, isStore, unwrap } from "./reactivity";
+export type { Store } from "./reactivity";

--- a/src/reactivity/index.ts
+++ b/src/reactivity/index.ts
@@ -1,2 +1,5 @@
 export { signal, computed, effect, batch, untracked } from "./signal";
 export type { Signal, ReadonlySignal } from "./signal";
+
+export { store, markRaw, isStore, unwrap } from "./store";
+export type { Store } from "./store";

--- a/src/reactivity/signal.ts
+++ b/src/reactivity/signal.ts
@@ -44,7 +44,8 @@ interface Subscriber {
   _running: boolean;
 }
 
-interface SignalNode<T = unknown> {
+/** @internal */
+export interface SignalNode<T = unknown> {
   _value: T;
   _subscribers: Set<Subscriber>;
 }
@@ -277,4 +278,36 @@ export function untracked<T>(fn: () => T): T {
   } finally {
     activeSubscriber = prev;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Internal building blocks for store() (Phase 2 of the deep-reactivity work).
+//
+// These are NOT public API — they're not re-exported from src/index.ts and are
+// marked @internal. The store implementation in ./store.ts uses them to
+// register and notify per-path signal nodes without duplicating the
+// subscriber-tracking machinery above.
+// ---------------------------------------------------------------------------
+
+/** @internal Whether the read happens inside a tracked context (computed/effect/etc). */
+export function _isTracking(): boolean {
+  return activeSubscriber !== null;
+}
+
+/** @internal Create a fresh node. The `_value` is unused by stores (raw[key] is the source of truth) but kept consistent with signal() shape. */
+export function _createNode<T>(value: T): SignalNode<T> {
+  return { _value: value, _subscribers: new Set() };
+}
+
+/** @internal Register the active subscriber (if any) as a dependent of this node. */
+export function _track(node: SignalNode): void {
+  if (activeSubscriber) {
+    node._subscribers.add(activeSubscriber);
+    activeSubscriber._sources.add(node);
+  }
+}
+
+/** @internal Notify subscribers, respecting the existing batch. */
+export function _notify(node: SignalNode): void {
+  notifySubscribers(node);
 }

--- a/src/reactivity/store.ts
+++ b/src/reactivity/store.ts
@@ -1,0 +1,306 @@
+// ---------------------------------------------------------------------------
+// store() — deep reactivity primitive.
+//
+// Peer to signal(): where signal() is shallow and reference-based, store() is
+// deep and path-granular. Mutating state.user.address.city = "x" notifies only
+// subscribers to that exact path. Built on the same SignalNode + Subscriber
+// machinery as signal() — no parallel reactivity system.
+//
+// Design contract: docs/STORES.md.
+// Patterns verified against competitor source: docs/STORE_RESEARCH_FINDINGS.md.
+// ---------------------------------------------------------------------------
+
+import {
+  type SignalNode,
+  _isTracking,
+  _createNode,
+  _track,
+  _notify,
+} from "./signal";
+
+// ---------------------------------------------------------------------------
+// Private symbols & flags. Not exported — module-scope only.
+//
+// $PROXY  — non-enumerable property on raw object, points to its Proxy.
+//           Gives us O(1) identity caching with no parallel WeakMap.
+//           (Pattern: Solid `packages/solid/store/src/store.ts:49-84`.)
+// $NODE   — non-enumerable property on raw object, points to its per-key
+//           SignalNode map. Allocated only when something tracks a read.
+// $RAW    — well-known symbol consumed by the get-trap so unwrap() works.
+// $KEYS   — sentinel key inside the $NODE record for iteration / key-set
+//           reactivity (for ... in, Object.keys). One node per parent,
+//           regardless of how many keys.
+//
+// FLAG_IS_STORE / FLAG_SKIP — string-keyed flags answered by the get-trap.
+//           (Pattern: Vue `packages/reactivity/src/constants.ts:11-24` +
+//           baseHandlers `:66-85`.)
+// ---------------------------------------------------------------------------
+
+const $RAW = Symbol("marjoram.raw");
+const $PROXY = Symbol("marjoram.proxy");
+const $NODE = Symbol("marjoram.node");
+const $KEYS = Symbol("marjoram.keys");
+
+const FLAG_IS_STORE = "__m_isStore";
+const FLAG_SKIP = "__m_skip";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+declare const STORE_BRAND: unique symbol;
+
+/**
+ * A deeply-reactive view of T. Structurally is T — readable and writable
+ * exactly like the underlying object. Reads inside a reactive context track
+ * the path; writes notify subscribers to that path.
+ */
+export type Store<T extends object> = T & { readonly [STORE_BRAND]: true };
+
+// ---------------------------------------------------------------------------
+// Boundary rules — what gets proxied.
+//
+// Plain objects and arrays only. Everything else (primitives, class instances,
+// Date / Map / Set / RegExp / Promise / typed arrays / DOM nodes, frozen
+// objects, markRaw'd values) is stored and returned by reference, untouched.
+// ---------------------------------------------------------------------------
+
+function shouldProxy(value: unknown): value is object {
+  if (value === null || typeof value !== "object") return false;
+  // markRaw opt-out
+  if ((value as Record<PropertyKey, unknown>)[FLAG_SKIP] === true) return false;
+  // Frozen objects can't be safely proxied (writes would throw).
+  if (Object.isFrozen(value)) return false;
+  // Only plain objects and arrays. Class instances, Date, Map, Set, DOM
+  // nodes, etc. all have non-Object/non-Array prototypes.
+  const proto = Object.getPrototypeOf(value);
+  return (
+    proto === Object.prototype || proto === Array.prototype || proto === null
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-raw-object SignalNode map. Created lazily, on first tracked read.
+// ---------------------------------------------------------------------------
+
+type NodeMap = Record<PropertyKey, SignalNode>;
+
+function getOrCreateNodeMap(raw: object): NodeMap {
+  let nodes = (raw as Record<symbol, unknown>)[$NODE] as NodeMap | undefined;
+  if (!nodes) {
+    nodes = Object.create(null) as NodeMap;
+    Object.defineProperty(raw, $NODE, {
+      value: nodes,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  }
+  return nodes;
+}
+
+/**
+ * Subscribe the active reactive context (if any) to raw[key]. No-op outside
+ * a tracked context — this is the "reads are free" guarantee.
+ */
+function trackPath(raw: object, key: PropertyKey): void {
+  if (!_isTracking()) return;
+  const nodes = getOrCreateNodeMap(raw);
+  let node = nodes[key];
+  if (!node) {
+    node = _createNode(undefined);
+    nodes[key] = node;
+  }
+  _track(node);
+}
+
+/**
+ * Track iteration / key-set reactivity. Used by `has` and `ownKeys` traps so
+ * `for (k in store)` and `Object.keys(store)` re-run when keys are added or
+ * removed.
+ */
+function trackKeys(raw: object): void {
+  if (!_isTracking()) return;
+  const nodes = getOrCreateNodeMap(raw);
+  let node = nodes[$KEYS];
+  if (!node) {
+    node = _createNode(undefined);
+    nodes[$KEYS] = node;
+  }
+  _track(node);
+}
+
+/** Fire subscribers of raw[key]. No-op if nothing ever tracked it. */
+function notifyPath(raw: object, key: PropertyKey): void {
+  const nodes = (raw as Record<symbol, unknown>)[$NODE] as NodeMap | undefined;
+  if (!nodes) return;
+  const node = nodes[key];
+  if (node) _notify(node);
+}
+
+/** Fire iteration / key-set subscribers. */
+function notifyKeys(raw: object): void {
+  const nodes = (raw as Record<symbol, unknown>)[$NODE] as NodeMap | undefined;
+  if (!nodes) return;
+  const node = nodes[$KEYS];
+  if (node) _notify(node);
+}
+
+// ---------------------------------------------------------------------------
+// The proxy handler. One instance, shared by every store. The handler is
+// stateless — all per-store state lives on the raw object via the private
+// symbols above.
+// ---------------------------------------------------------------------------
+
+const storeHandler: ProxyHandler<object> = {
+  get(raw, key, receiver) {
+    // Flag interceptions — answered without reading raw or tracking.
+    if (key === FLAG_IS_STORE) return true;
+    if (key === $RAW) return raw;
+
+    const value = Reflect.get(raw, key, receiver);
+
+    // Don't track reads of private symbols, function values, or inherited
+    // accessors that aren't part of the user's data model.
+    if (typeof key !== "symbol") {
+      trackPath(raw, key);
+    }
+
+    if (shouldProxy(value)) {
+      return wrap(value);
+    }
+    return value;
+  },
+
+  set(raw, key, newValue, receiver) {
+    const oldValue = Reflect.get(raw, key, receiver);
+    if (Object.is(oldValue, newValue)) return true;
+
+    const isNewKey = !(key in raw);
+    const ok = Reflect.set(raw, key, newValue, receiver);
+    if (!ok) return false;
+
+    notifyPath(raw, key);
+    if (isNewKey) notifyKeys(raw);
+    return true;
+  },
+
+  deleteProperty(raw, key) {
+    if (!(key in raw)) return true;
+    const ok = Reflect.deleteProperty(raw, key);
+    if (!ok) return false;
+    notifyPath(raw, key);
+    notifyKeys(raw);
+    return true;
+  },
+
+  has(raw, key) {
+    trackKeys(raw);
+    return Reflect.has(raw, key);
+  },
+
+  ownKeys(raw) {
+    trackKeys(raw);
+    return Reflect.ownKeys(raw);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Identity cache — same raw → same proxy across all reads.
+// ---------------------------------------------------------------------------
+
+function wrap<T extends object>(raw: T): T {
+  let proxy = (raw as Record<symbol, unknown>)[$PROXY] as T | undefined;
+  if (!proxy) {
+    proxy = new Proxy(raw, storeHandler) as T;
+    Object.defineProperty(raw, $PROXY, {
+      value: proxy,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  }
+  return proxy;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a deeply-reactive store from a plain object or array.
+ *
+ * - Reads inside a reactive context (`computed`, `effect`, `html` templates)
+ *   register the active context as a subscriber to the exact path read.
+ * - Writes notify only the subscribers to the affected path.
+ * - `state.user === state.user` holds across reads — nested proxies are cached
+ *   on the raw object via a non-enumerable symbol.
+ * - Reads outside any reactive context allocate nothing.
+ *
+ * @example
+ * ```ts
+ * const state = store({ user: { name: "Alice", age: 30 } });
+ *
+ * effect(() => console.log(state.user.name));   // logs "Alice"
+ * state.user.age = 31;                          // ← effect does NOT re-run
+ * state.user.name = "Bob";                      // ← effect re-runs, logs "Bob"
+ * ```
+ */
+export function store<T extends object>(initial: T): Store<T> {
+  // Already a store — return as-is (idempotent, handles cycles).
+  if ((initial as Record<PropertyKey, unknown>)[FLAG_IS_STORE] === true) {
+    return initial as Store<T>;
+  }
+  // markRaw'd or built-in — gracefully pass through without proxying.
+  if (!shouldProxy(initial)) {
+    return initial as Store<T>;
+  }
+  return wrap(initial) as Store<T>;
+}
+
+/**
+ * Mark a plain object or array so `store()` will never proxy it. Reads return
+ * the raw value; mutations to nested keys are invisible to reactivity.
+ *
+ * Use for embedding non-reactive payloads (parsed AST, large config blob, 3rd-
+ * party state) inside a store.
+ *
+ * @example
+ * ```ts
+ * const state = store({
+ *   user: { name: "Alice" },          // reactive
+ *   ast: markRaw(largeParsedTree),    // ignored by reactivity
+ * });
+ * ```
+ */
+export function markRaw<T extends object>(value: T): T {
+  Object.defineProperty(value, FLAG_SKIP, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  });
+  return value;
+}
+
+/** Type guard. `true` for values created by `store()`. */
+export function isStore(value: unknown): value is Store<object> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as Record<PropertyKey, unknown>)[FLAG_IS_STORE] === true
+  );
+}
+
+/**
+ * Return the raw object backing a store. Mutating the raw object BYPASSES
+ * reactivity — no subscribers fire. Use only for interop with code that
+ * requires a plain object (e.g., `structuredClone`, libraries that key off
+ * object identity, JSON serialization through the proxy is fine without this).
+ */
+export function unwrap<T extends object>(value: Store<T> | T): T {
+  if (isStore(value)) {
+    return (value as unknown as Record<symbol, unknown>)[$RAW] as T;
+  }
+  return value as T;
+}


### PR DESCRIPTION
## Summary

Phase 2 — the core `store()` implementation. Stacks on PR #10 (Phase 1 design + research). Target base will be `main` once #10 merges.

- **New file:** `src/reactivity/store.ts` (~260 LoC) — `store()`, `markRaw()`, `isStore()`, `unwrap()`, type `Store<T>`.
- **Refactor:** `src/reactivity/signal.ts` adds 4 `@internal` exports (`_isTracking`, `_createNode`, `_track`, `_notify`) and a `@internal` `SignalNode` type for `store.ts` to compose with. **No behavior change** in the existing primitives — locked by the 209 existing tests still passing byte-identical.
- **New tests:** `__tests__/reactivity/store.test.ts` — 35 tests, all passing.

## What's in scope for this PR

All of Phase 2 per [docs/STORE_IMPLEMENTATION_PLAN.md](docs/STORE_IMPLEMENTATION_PLAN.md):

- **Lazy nested proxying** — `state.user === state.user` holds; no allocation on plain reads.
- **Identity cache** via `$PROXY` symbol on raw (Solid pattern, not a parallel WeakMap).
- **Path-level granularity** — writing one path notifies *only* that path's subscribers. Sibling effects untouched.
- **Reads-are-free guarantee** — verified by a test that asserts no `$NODE` symbol is allocated on the raw object after untracked reads.
- **Iteration / key-set tracking** via single `$KEYS` sentinel — `for...in` and `Object.keys` re-run on key add/delete, not on existing-key value changes.
- **`markRaw`** — opt-out for plain objects you don't want proxied.
- **Boundary rules** — `Date`, `Map`, `Set`, class instances, frozen objects pass through unproxied (verified by test).
- **Composes with the existing `computed`/`effect`/`batch`/`untracked`** — no new batch system, no parallel reactivity.

## Not in this PR (next phases)

- **Phase 3:** Array mutating-method batching (Solid `mutable.ts:55-58` pattern — wrap Array prototype methods in `batch()`).
- **Phase 4:** View-layer integration (`$`-prefix on stores, `useViewModel` accepts stores, `repeat()` integration).
- **Phase 5:** `snapshot()`, `subscribe()`, devtools formatter, `Path<T>` / `PathValue<T,P>` types, dev-mode warnings, the `@rollup/plugin-replace` dev-dependency add.

## Verification

```
✓ npm run type-check     — clean
✓ npm run lint           — 0 errors (49 pre-existing warnings, none in files I touched)
✓ npm test               — 244/244 passing (209 existing + 35 new)
✓ npm run format:check   — no warnings on my files
```

## Test plan

- [x] Existing 209 tests pass byte-identical (non-breaking-change rule).
- [x] 35 new tests cover: basic shape, identity caching, path granularity, reads-are-free, computed integration, batch coalescing, untracked, key add/delete, markRaw, isStore, unwrap, boundary rules.
- [ ] CI green on Node 16/18/20.
- [ ] Manual smoke test in the demo widget once Phase 4 lands (deferred).

## Targets v1.1.0

Combined with Phases 3+4, ships as v1.1.0-rc.0 prerelease per the rollout cadence in [docs/STORE_IMPLEMENTATION_PLAN.md](docs/STORE_IMPLEMENTATION_PLAN.md). Stable v1.1.0 after ≥1 week of prerelease dogfooding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)