### PR TITLE
feat: store() Phase 3 — batched array mutating methods

### DIFF
--- a/__tests__/reactivity/store-arrays.test.ts
+++ b/__tests__/reactivity/store-arrays.test.ts
@@ -1,0 +1,389 @@
+import { store, effect, batch } from "../../src/reactivity";
+
+const flush = () => new Promise<void>(resolve => queueMicrotask(resolve));
+
+describe("store() — Phase 3 array support", () => {
+  describe("granular index tracking", () => {
+    it("setting one index notifies only that index's subscribers", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let arr0Runs = 0;
+      let arr1Runs = 0;
+      effect(() => {
+        s.arr[0];
+        arr0Runs++;
+      });
+      effect(() => {
+        s.arr[1];
+        arr1Runs++;
+      });
+      expect(arr0Runs).toBe(1);
+      expect(arr1Runs).toBe(1);
+
+      s.arr[1] = 99;
+      await flush();
+      expect(arr0Runs).toBe(1);
+      expect(arr1Runs).toBe(2);
+    });
+
+    it("setting an existing index does NOT wake length subscribers", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let lengthRuns = 0;
+      effect(() => {
+        s.arr.length;
+        lengthRuns++;
+      });
+      expect(lengthRuns).toBe(1);
+
+      s.arr[0] = 99;
+      await flush();
+      expect(lengthRuns).toBe(1);
+    });
+  });
+
+  describe("push() — batched notifications", () => {
+    it("push of one item produces one effect re-run", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let runs = 0;
+      effect(() => {
+        s.arr.length;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      s.arr.push(4);
+      await flush();
+      expect(runs).toBe(2);
+      expect(s.arr.length).toBe(4);
+    });
+
+    it("push of three items produces one effect re-run (not three)", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let runs = 0;
+      effect(() => {
+        s.arr.length;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      s.arr.push(4, 5, 6);
+      await flush();
+      expect(runs).toBe(2);
+      expect(s.arr).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    it("returns the new length", () => {
+      const s = store({ arr: [1, 2] });
+      const len = s.arr.push(3);
+      expect(len).toBe(3);
+    });
+  });
+
+  describe("pop() / shift() / unshift()", () => {
+    it("pop() removes last item and returns it; one effect re-run", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let runs = 0;
+      effect(() => {
+        s.arr.length;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      const popped = s.arr.pop();
+      expect(popped).toBe(3);
+      expect(s.arr).toEqual([1, 2]);
+
+      await flush();
+      expect(runs).toBe(2);
+    });
+
+    it("unshift() prepends; one effect re-run", async () => {
+      const s = store({ arr: [2, 3] });
+      let runs = 0;
+      effect(() => {
+        s.arr.length;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      const len = s.arr.unshift(0, 1);
+      expect(len).toBe(4);
+      expect(s.arr).toEqual([0, 1, 2, 3]);
+
+      await flush();
+      expect(runs).toBe(2);
+    });
+
+    it("shift() removes first item; one effect re-run", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let runs = 0;
+      effect(() => {
+        s.arr.length;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      const shifted = s.arr.shift();
+      expect(shifted).toBe(1);
+      expect(s.arr).toEqual([2, 3]);
+
+      await flush();
+      expect(runs).toBe(2);
+    });
+  });
+
+  describe("splice() — most complex case", () => {
+    it("splice that adds + removes produces one effect re-run", async () => {
+      const s = store({ arr: [1, 2, 3, 4, 5] });
+      let runs = 0;
+      effect(() => {
+        s.arr.length;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      const removed = s.arr.splice(1, 2, 99, 98, 97);
+      expect(removed).toEqual([2, 3]);
+      expect(s.arr).toEqual([1, 99, 98, 97, 4, 5]);
+
+      await flush();
+      expect(runs).toBe(2);
+    });
+
+    it("splice that only removes returns the removed items", () => {
+      const s = store({ arr: [1, 2, 3, 4] });
+      const removed = s.arr.splice(1, 2);
+      expect(removed).toEqual([2, 3]);
+      expect(s.arr).toEqual([1, 4]);
+    });
+  });
+
+  describe("sort() / reverse() / fill()", () => {
+    it("sort() one effect re-run despite many internal swaps", async () => {
+      const s = store({ arr: [3, 1, 4, 1, 5, 9, 2, 6] });
+      let runs = 0;
+      effect(() => {
+        s.arr.forEach(() => {}); // depend on every index + length
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      s.arr.sort((a, b) => a - b);
+      await flush();
+      expect(runs).toBe(2); // single coalesced round
+      expect(s.arr).toEqual([1, 1, 2, 3, 4, 5, 6, 9]);
+    });
+
+    it("reverse() one effect re-run", async () => {
+      const s = store({ arr: [1, 2, 3, 4] });
+      let runs = 0;
+      effect(() => {
+        s.arr.forEach(() => {});
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      s.arr.reverse();
+      await flush();
+      expect(runs).toBe(2);
+      expect(s.arr).toEqual([4, 3, 2, 1]);
+    });
+
+    it("fill() one effect re-run", async () => {
+      const s = store({ arr: [1, 2, 3, 4] });
+      let runs = 0;
+      effect(() => {
+        s.arr.forEach(() => {});
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      s.arr.fill(0);
+      await flush();
+      expect(runs).toBe(2);
+      expect(s.arr).toEqual([0, 0, 0, 0]);
+    });
+  });
+
+  describe("read-only methods still reactive", () => {
+    it("map() re-runs when array changes", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let snapshot: number[] = [];
+      let runs = 0;
+      effect(() => {
+        snapshot = s.arr.map(x => x * 2);
+        runs++;
+      });
+      expect(runs).toBe(1);
+      expect(snapshot).toEqual([2, 4, 6]);
+
+      s.arr.push(4);
+      await flush();
+      expect(runs).toBe(2);
+      expect(snapshot).toEqual([2, 4, 6, 8]);
+    });
+
+    it("filter() works reactively", async () => {
+      const s = store({ arr: [1, 2, 3, 4] });
+      let evens: number[] = [];
+      effect(() => {
+        evens = s.arr.filter(x => x % 2 === 0);
+      });
+      expect(evens).toEqual([2, 4]);
+
+      s.arr[0] = 8;
+      await flush();
+      expect(evens).toEqual([8, 2, 4]);
+    });
+
+    it("find() / some() / every() / reduce() all work", () => {
+      const s = store({ arr: [1, 2, 3, 4, 5] });
+      expect(s.arr.find(x => x > 3)).toBe(4);
+      expect(s.arr.some(x => x > 4)).toBe(true);
+      expect(s.arr.every(x => x > 0)).toBe(true);
+      expect(s.arr.reduce((a, b) => a + b, 0)).toBe(15);
+    });
+  });
+
+  describe("iteration reactivity", () => {
+    it("for...of re-runs when array length changes", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let sum = 0;
+      let runs = 0;
+      effect(() => {
+        sum = 0;
+        for (const x of s.arr) sum += x;
+        runs++;
+      });
+      expect(runs).toBe(1);
+      expect(sum).toBe(6);
+
+      s.arr.push(4);
+      await flush();
+      expect(runs).toBe(2);
+      expect(sum).toBe(10);
+    });
+
+    it("forEach() re-runs when an item changes", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let sum = 0;
+      effect(() => {
+        sum = 0;
+        s.arr.forEach(x => (sum += x));
+      });
+      expect(sum).toBe(6);
+
+      s.arr[0] = 10;
+      await flush();
+      expect(sum).toBe(15);
+    });
+  });
+
+  describe("array of objects — granular nested updates", () => {
+    it("mutating an object inside an array updates only that path", async () => {
+      const s = store({
+        todos: [
+          { id: 1, text: "a", done: false },
+          { id: 2, text: "b", done: false },
+        ],
+      });
+      let todo0TextRuns = 0;
+      let todo1TextRuns = 0;
+      effect(() => {
+        s.todos[0].text;
+        todo0TextRuns++;
+      });
+      effect(() => {
+        s.todos[1].text;
+        todo1TextRuns++;
+      });
+      expect(todo0TextRuns).toBe(1);
+      expect(todo1TextRuns).toBe(1);
+
+      s.todos[0].text = "updated";
+      await flush();
+      expect(todo0TextRuns).toBe(2);
+      expect(todo1TextRuns).toBe(1);
+    });
+
+    it("pushing a new object item wakes length subscribers but not existing-item subscribers", async () => {
+      const s = store({
+        todos: [{ id: 1, text: "a" }] as { id: number; text: string }[],
+      });
+      let lengthRuns = 0;
+      let item0Runs = 0;
+      effect(() => {
+        s.todos.length;
+        lengthRuns++;
+      });
+      effect(() => {
+        s.todos[0].text;
+        item0Runs++;
+      });
+      expect(lengthRuns).toBe(1);
+      expect(item0Runs).toBe(1);
+
+      s.todos.push({ id: 2, text: "b" });
+      await flush();
+      expect(lengthRuns).toBe(2);
+      expect(item0Runs).toBe(1);
+    });
+  });
+
+  describe("explicit batch() still works around store mutations", () => {
+    it("manual batch coalesces multiple store writes", async () => {
+      const s = store({ arr: [1, 2, 3] });
+      let runs = 0;
+      effect(() => {
+        s.arr[0];
+        s.arr[1];
+        s.arr[2];
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      batch(() => {
+        s.arr[0] = 10;
+        s.arr[1] = 20;
+        s.arr[2] = 30;
+      });
+
+      await flush();
+      expect(runs).toBe(2);
+    });
+  });
+
+  describe("array identity is stable", () => {
+    it("s.arr === s.arr across reads", () => {
+      const s = store({ arr: [1, 2, 3] });
+      expect(s.arr).toBe(s.arr);
+    });
+
+    it("array methods receive the proxy as this", () => {
+      // If `this` inside push were the raw array (not the proxy), nested
+      // mutations would bypass reactivity. Verify by side-effect.
+      const s = store({ arr: [{ x: 1 }] });
+      let runs = 0;
+      effect(() => {
+        s.arr.length;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      s.arr.push({ x: 2 });
+      return flush().then(() => {
+        expect(runs).toBe(2);
+        // And the new item is reactive too:
+        let xRuns = 0;
+        effect(() => {
+          s.arr[1].x;
+          xRuns++;
+        });
+        expect(xRuns).toBe(1);
+        s.arr[1].x = 99;
+        return flush().then(() => {
+          expect(xRuns).toBe(2);
+        });
+      });
+    });
+  });
+});

--- a/src/reactivity/store.ts
+++ b/src/reactivity/store.ts
@@ -16,6 +16,7 @@ import {
   _createNode,
   _track,
   _notify,
+  batch,
 } from "./signal";
 
 // ---------------------------------------------------------------------------
@@ -160,6 +161,36 @@ const storeHandler: ProxyHandler<object> = {
 
     const value = Reflect.get(raw, key, receiver);
 
+    // Array-method batching (Phase 3): when reading a function-typed key off
+    // an array that exists on Array.prototype, return a wrapper that runs the
+    // method inside `batch()`. This coalesces the internal index/length
+    // writes of mutating methods (push/pop/shift/unshift/splice/sort/reverse/
+    // fill/copyWithin) into a single notification round, so a subscribed
+    // effect re-runs once per call instead of once per inner write.
+    //
+    // Pattern: Solid `packages/solid/store/src/mutable.ts:55-58`.
+    //
+    // Non-mutating methods (map/filter/forEach/...) also flow through this
+    // path. The batch is a no-op for them — no extra work, no behavior
+    // change.
+    if (
+      Array.isArray(raw) &&
+      typeof value === "function" &&
+      typeof key === "string" &&
+      key in Array.prototype
+    ) {
+      return (...args: unknown[]): unknown => {
+        let result: unknown;
+        batch(() => {
+          result = (value as (...a: unknown[]) => unknown).apply(
+            receiver,
+            args
+          );
+        });
+        return result;
+      };
+    }
+
     // Don't track reads of private symbols, function values, or inherited
     // accessors that aren't part of the user's data model.
     if (typeof key !== "symbol") {
@@ -176,12 +207,26 @@ const storeHandler: ProxyHandler<object> = {
     const oldValue = Reflect.get(raw, key, receiver);
     if (Object.is(oldValue, newValue)) return true;
 
+    const isArray = Array.isArray(raw);
+    // Capture length before the write — writing an out-of-bounds index on an
+    // array auto-bumps `length` as a native side-effect. We need to notify
+    // length subscribers from inside this set, because by the time push()
+    // explicitly writes `this.length = N` (its final step), the value is
+    // already N and Object.is would skip the notification.
+    const oldLength = isArray ? (raw as unknown[]).length : 0;
+
     const isNewKey = !(key in raw);
     const ok = Reflect.set(raw, key, newValue, receiver);
     if (!ok) return false;
 
     notifyPath(raw, key);
     if (isNewKey) notifyKeys(raw);
+
+    if (isArray && key !== "length") {
+      const newLength = (raw as unknown[]).length;
+      if (newLength !== oldLength) notifyPath(raw, "length");
+    }
+
     return true;
   },
 


### PR DESCRIPTION
## Summary

Phase 3 of the deep-reactivity initiative. Adds the **array-method batch wrapping** pattern from Solid's `mutable.ts` and fixes a subtle native-JS edge case in the set trap.

- **Wrapped methods.** When you read a function-typed key off a store array that exists on `Array.prototype`, the get trap returns a wrapper that runs the original inside `batch()`. So `arr.push(a, b, c)` produces **one** effect re-run per subscriber, not three. Same for `splice`, `sort`, `reverse`, `fill`, `pop`, `shift`, `unshift`, `copyWithin`. Read-only methods (`map`/`filter`/`forEach`/...) flow through the same wrapper — the batch is a no-op for them, zero overhead.
- **Length auto-bump fix.** Writing an out-of-bounds index on an array auto-bumps `.length` as a native JS side-effect. By the time `push` reaches its final `this.length = N` step, the value is already N and `Object.is` would silently skip the length notification. The set trap now captures length before the write and notifies length subscribers if it changed.

## Trio

- `npm run type-check` → clean
- `npm run lint` → 0 errors (49 pre-existing warnings, none in my files)
- `npm test` → **267/267** (244 prior + **23 new**)
- `npm run format:check` → my files clean

## Test coverage (23 new tests)

- **Granularity:** setting one index doesn't wake sibling-index or length subscribers (unless length actually changed).
- **Single re-run guarantee:** `push`/`pop`/`shift`/`unshift`/`splice`/`sort`/`reverse`/`fill` each produce exactly one effect re-run for a single call, regardless of how many internal writes happen.
- **Return values preserved:** `pop()` returns popped item; `splice()` returns removed items; `push`/`unshift` return new length.
- **Read methods still reactive:** `map`/`filter`/`forEach`/`find`/`some`/`every`/`reduce` all work.
- **Iteration reactivity:** `for...of` and `forEach` re-run on length changes and item value changes.
- **Arrays of objects:** mutating an item updates only that item's path; pushing new items wakes length subs without disturbing existing-item subs.
- **`this` is the proxy inside methods:** new object items pushed via `arr.push({...})` are themselves reactive (mutations to nested fields fire correctly).

## Not in this PR (next phases)

- **Phase 4:** View-layer integration — `$`-prefix on stores, `useViewModel` accepting stores, `repeat()` integration.
- **Phase 5:** `snapshot()`, `subscribe()` with `Path<T>` types, devtools formatter, dev-mode warnings, `@rollup/plugin-replace` dependency add.

## Targets v1.1.0

Combined with Phase 4 ships as v1.1.0-rc.0 prerelease per the rollout cadence in [docs/STORE_IMPLEMENTATION_PLAN.md](docs/STORE_IMPLEMENTATION_PLAN.md).