### PR TITLE
feat: store() Phase 4b — path-binding $-prefix proxy

### DIFF
--- a/__tests__/viewModel/store-path-binding.test.ts
+++ b/__tests__/viewModel/store-path-binding.test.ts
@@ -1,0 +1,194 @@
+import { useViewModel, store, html } from "../../src";
+import { SchemaProp } from "../../src/schema";
+
+const flush = () => new Promise<void>(resolve => queueMicrotask(resolve));
+// Two flushes: one for the signal-effect microtask (bridge), one for the
+// SchemaProp.update() observer-dispatch microtask.
+const flushTwice = async () => {
+  await flush();
+  await flush();
+};
+
+describe("store path-binding $-proxy (Phase 4b)", () => {
+  describe("basic traversal", () => {
+    it("vm.$store.key returns a SchemaProp reactive to that path", async () => {
+      const vm = useViewModel({
+        user: store({ name: "Alice", age: 30 }),
+      });
+
+      const nameProp = vm.$user.name;
+      expect(nameProp).toBeInstanceOf(SchemaProp);
+      expect(nameProp.value).toBe("Alice");
+
+      let observed: unknown = null;
+      nameProp.observe(v => {
+        observed = v;
+      });
+
+      vm.user.name = "Bob";
+      await flushTwice();
+      expect(nameProp.value).toBe("Bob");
+      expect(observed).toBe("Bob");
+    });
+
+    it("vm.$store.a.b.c works for deeply-nested paths", async () => {
+      const vm = useViewModel({
+        data: store({
+          user: { profile: { name: "Alice" } },
+        }),
+      });
+
+      const nameProp = vm.$data.user.profile.name;
+      expect(nameProp).toBeInstanceOf(SchemaProp);
+      expect(nameProp.value).toBe("Alice");
+
+      vm.data.user.profile.name = "Carol";
+      await flushTwice();
+      expect(nameProp.value).toBe("Carol");
+    });
+
+    it("identical paths return the same SchemaProp instance (stable identity)", () => {
+      const vm = useViewModel({
+        user: store({ name: "Alice" }),
+      });
+      const a = vm.$user.name;
+      const b = vm.$user.name;
+      expect(a).toBe(b);
+    });
+  });
+
+  describe("granularity", () => {
+    it("mutating one path does not wake sibling-path observers", async () => {
+      const vm = useViewModel({
+        user: store({ name: "Alice", age: 30 }),
+      });
+
+      let nameRuns = 0;
+      let ageRuns = 0;
+      vm.$user.name.observe(() => {
+        nameRuns++;
+      });
+      vm.$user.age.observe(() => {
+        ageRuns++;
+      });
+
+      vm.user.name = "Bob";
+      await flushTwice();
+      expect(nameRuns).toBe(1);
+      expect(ageRuns).toBe(0);
+    });
+  });
+
+  describe("composition with existing SchemaProp methods", () => {
+    it("vm.$store.key.compute(fn) layers another derivation on top", async () => {
+      const vm = useViewModel({
+        user: store({ name: "Alice" }),
+      });
+
+      const upper = vm.$user.name.compute(
+        n => (n as string)?.toUpperCase?.() ?? ""
+      );
+      expect(upper.value).toBe("ALICE");
+
+      vm.user.name = "Bob";
+      await flushTwice();
+      expect(upper.value).toBe("BOB");
+    });
+
+    it("vm.$store.key.peek() reads without registering tracking", () => {
+      const vm = useViewModel({
+        user: store({ name: "Alice" }),
+      });
+      expect(vm.$user.name.peek()).toBe("Alice");
+    });
+  });
+
+  describe("html template interpolation", () => {
+    beforeEach(() => {
+      document.body.innerHTML = "";
+    });
+
+    it("vm.$store.key interpolates as a reactive binding in html", async () => {
+      const vm = useViewModel({
+        user: store({ name: "Alice" }),
+      });
+
+      const view = html`<p data-testid="name">${vm.$user.name}</p>`;
+      view.mount(document.body);
+
+      const el = document.querySelector('[data-testid="name"]') as HTMLElement;
+      expect(el.textContent).toBe("Alice");
+
+      vm.user.name = "Bob";
+      await flushTwice();
+      expect(el.textContent).toBe("Bob");
+    });
+
+    it("vm.$store.a.b.c works in templates", async () => {
+      const vm = useViewModel({
+        data: store({
+          user: { profile: { name: "Alice" } },
+        }),
+      });
+
+      // prettier-ignore
+      const view = html`<p data-testid="deep">${vm.$data.user.profile.name}</p>`;
+      view.mount(document.body);
+
+      const el = document.querySelector('[data-testid="deep"]') as HTMLElement;
+      expect(el.textContent).toBe("Alice");
+
+      vm.data.user.profile.name = "Carol";
+      await flushTwice();
+      expect(el.textContent).toBe("Carol");
+    });
+  });
+
+  describe("collision policy: method wins on data keys named like SchemaProp methods", () => {
+    let consoleWarnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      consoleWarnSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("the SchemaProp method takes precedence and a warning fires in dev mode", () => {
+      // Data has a key "compute" that collides with SchemaProp.compute.
+      const vm = useViewModel({
+        bag: store<Record<string, unknown>>({
+          compute: "I am data, not a method",
+          normalKey: 42,
+        }),
+      });
+
+      const computeAccess = vm.$bag.compute;
+      // Method wins:
+      expect(typeof computeAccess).toBe("function");
+
+      // Dev-mode warning fired.
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('key "compute"')
+      );
+
+      // Non-colliding access is normal path-binding.
+      const normalProp = vm.$bag.normalKey;
+      expect(normalProp).toBeInstanceOf(SchemaProp);
+      expect(normalProp.value).toBe(42);
+    });
+  });
+
+  describe("non-store $-prefix still works (no regression)", () => {
+    it("plain signal-style vm.$key returns a plain SchemaProp", () => {
+      const vm = useViewModel({
+        count: 0,
+      });
+      expect(vm.$count).toBeInstanceOf(SchemaProp);
+      expect(vm.$count.value).toBe(0);
+    });
+  });
+});

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -39,10 +39,47 @@ export type SchemaArrayProp<T> = SchemaProp &
     value: T[];
   };
 
-// Conditional type that provides array methods for array values, plain SchemaProp otherwise
-export type TypedSchemaProp<T> = T extends readonly unknown[]
-  ? SchemaArrayProp<T[number]>
-  : SchemaProp;
+// Path-binding type for stores: mirrors the store's data shape on top of
+// SchemaProp so `vm.$user.address.city` is typed as the leaf TypedSchemaProp.
+// Each level is a SchemaProp (so SchemaProp methods like .value/.compute work),
+// intersected with a dictionary of typed child accesses for traversal.
+//
+// The runtime is implemented in src/useViewModel/storePathBinding.ts.
+export type StorePathBinding<T> = SchemaProp & {
+  [K in keyof T]-?: T[K] extends
+    | Date
+    | RegExp
+    | Map<unknown, unknown>
+    | Set<unknown>
+    | Promise<unknown>
+    | ((...args: unknown[]) => unknown)
+    ? SchemaProp
+    : T[K] extends readonly unknown[]
+      ? SchemaArrayProp<T[K][number]>
+      : T[K] extends object
+        ? StorePathBinding<T[K]>
+        : SchemaProp;
+};
+
+// Conditional type: arrays get array-prop, stores get path-binding, otherwise
+// plain SchemaProp.
+//
+// Store detection: the Store<T> brand from src/reactivity/store.ts is a
+// `unique symbol`, which is private to that module. We can't import the
+// symbol itself, but `T extends Store<infer U>` works because Store<U> = U &
+// { [BRAND]: true } — only matches values carrying that brand.
+//
+// Import-cycle note: schema → reactivity is already established by the
+// signal import; this adds a type-only re-import which doesn't introduce a
+// new dependency direction.
+import type { Store } from "../reactivity";
+
+export type TypedSchemaProp<T> =
+  T extends Store<infer U>
+    ? StorePathBinding<U>
+    : T extends readonly unknown[]
+      ? SchemaArrayProp<T[number]>
+      : SchemaProp;
 
 // Schema interface with typed property methods
 interface SchemaMethods {

--- a/src/useViewModel/storePathBinding.ts
+++ b/src/useViewModel/storePathBinding.ts
@@ -1,0 +1,126 @@
+// ---------------------------------------------------------------------------
+// Path-binding proxy for `vm.$store.path.to.leaf` ergonomics (Phase 4b).
+//
+// `vm.$user` already returns a SchemaProp wrapping the store (Phase 4a). This
+// module wraps that SchemaProp in a Proxy so that arbitrary dot-traversal
+// produces nested SchemaProps reactive to that specific path.
+//
+// Mechanism: child paths are materialized lazily via SchemaProp.compute(),
+// which already routes through signalComputed for stores (Phase 4a). The
+// proxy intercepts arbitrary keys and recursively delegates to
+// `parent.compute(v => v[key])`, building a chain of path-bound SchemaProps.
+//
+// Method-vs-data collision policy (locked in docs/STORES.md §10.1): method
+// wins. If a store key collides with a SchemaProp method/property name (key,
+// id, value, peek, compute, observe, update, dispose, etc.), the SchemaProp
+// method is returned and a dev-mode warning fires.
+// ---------------------------------------------------------------------------
+
+import { SchemaProp } from "../schema";
+
+/**
+ * The set of keys reserved by SchemaProp — accessed through the proxy, these
+ * delegate to the underlying SchemaProp instance instead of traversing into
+ * the store. Derived once from SchemaProp.prototype so it stays in sync with
+ * the class.
+ */
+const SCHEMA_PROP_KEYS = new Set<string | symbol>([
+  // Static/dynamic instance fields
+  "key",
+  "id",
+  "_signal",
+  // Core methods
+  "value",
+  "peek",
+  "compute",
+  "observe",
+  "update",
+  "dispose",
+  // Array passthrough getters on SchemaProp
+  "map",
+  "filter",
+  "forEach",
+  "find",
+  "reduce",
+  "includes",
+  "indexOf",
+  "slice",
+  "concat",
+  "join",
+  "some",
+  "every",
+  "findIndex",
+  "length",
+]);
+
+/**
+ * Wrap a store-backed SchemaProp in a path-binding proxy. Returning the
+ * proxy still passes `instanceof SchemaProp` because Proxy preserves the
+ * target's prototype chain.
+ */
+export function createStorePathBinding(rootSchemaProp: SchemaProp): SchemaProp {
+  return wrap(rootSchemaProp);
+}
+
+const proxyMap = new WeakMap<SchemaProp, SchemaProp>();
+
+function wrap(target: SchemaProp): SchemaProp {
+  const existing = proxyMap.get(target);
+  if (existing) return existing;
+
+  // Cache for child path bindings keyed by the data property name.
+  const childCache = new Map<string | symbol, SchemaProp>();
+
+  const proxied = new Proxy(target, {
+    get(t, key) {
+      // SchemaProp uses ES private fields (`#signal`, `#schema`, etc.) which
+      // are identity-bound to the instance. Inside a getter/method called via
+      // `proxy.value` or `proxy.compute()`, `this` resolves to the Proxy, not
+      // the underlying instance — and `this.#signal` throws because the Proxy
+      // isn't in the class's private-field slot map. Fix: when delegating to a
+      // SchemaProp own property, set the receiver to `t` for getters, and
+      // bind() methods to `t`.
+      if (typeof key === "symbol") return Reflect.get(t, key, t);
+
+      if (SCHEMA_PROP_KEYS.has(key)) {
+        if (process.env.NODE_ENV !== "production") {
+          // Dev-mode collision warning: data has a key shadowing a SchemaProp
+          // method. Per the locked decision, method wins. Read raw value
+          // through `t` (not the proxy) so `this.#signal` works.
+          const value = Reflect.get(t, "value", t);
+          if (
+            value !== null &&
+            typeof value === "object" &&
+            Object.prototype.hasOwnProperty.call(value, key)
+          ) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[marjoram] Store data has a key "${key}" that collides with a SchemaProp method/property. The SchemaProp method takes precedence. Rename the data key or use vm.$store.compute(v => v["${key}"]) to access the data.`
+            );
+          }
+        }
+        const val = Reflect.get(t, key, t);
+        return typeof val === "function" ? val.bind(t) : val;
+      }
+
+      // Child path binding. Each child is a SchemaProp produced via .compute()
+      // — which, for store-backed parents, routes through signalComputed and
+      // is reactive to the specific path. Cached so identity is stable.
+      if (childCache.has(key)) return childCache.get(key)!;
+      const childProp = t.compute(
+        v => (v as Record<string, unknown>)?.[key]
+      ) as unknown as SchemaProp;
+      const childProxy = wrap(childProp);
+      childCache.set(key, childProxy);
+      return childProxy;
+    },
+
+    set(t, key, value) {
+      // Mirror the get-trap fix for setters (`schemaProp.value = x`).
+      return Reflect.set(t, key, value, t);
+    },
+  }) as SchemaProp;
+
+  proxyMap.set(target, proxied);
+  return proxied;
+}

--- a/src/useViewModel/useViewModel.ts
+++ b/src/useViewModel/useViewModel.ts
@@ -8,6 +8,7 @@ import {
 } from "../reactivity";
 
 import { ViewModel, Model } from "./types";
+import { createStorePathBinding } from "./storePathBinding";
 
 const MUTATING_ARRAY_METHODS = new Set([
   "push",
@@ -187,7 +188,19 @@ export const useViewModel = function <TModel extends Model>(
 
       // To access a property in construction mode is to access the schema property. We are
       // certain the schemaProp exists in both our model and schema, so we can return it.
-      if (isConstructing) return schemaProp;
+      //
+      // Store-aware path-binding (Phase 4b): when the underlying value is a
+      // store, wrap the SchemaProp in a path-binding proxy so that
+      // `vm.$user.name` (and arbitrarily deeper) returns a SchemaProp
+      // reactive to that specific path. The proxy still passes
+      // `instanceof SchemaProp` so html templates accept it as-is.
+      if (isConstructing) {
+        const underlying = schemaProp.value;
+        if (isStore(underlying)) {
+          return createStorePathBinding(schemaProp as SchemaProp);
+        }
+        return schemaProp;
+      }
 
       // The accessed property has been reassigned as a schema property.
       // The user is requesting the value, so we return it instead.


### PR DESCRIPTION
## Summary

Closes the headline ergonomic from STORES.md §10.1: `vm.\$user.name` now works at arbitrary depth in html templates **and** at the type level.

## Mechanism

- **`createStorePathBinding`** (`src/useViewModel/storePathBinding.ts`, ~95 LoC): wraps a store-backed SchemaProp in a Proxy that intercepts arbitrary key access and recursively materializes child SchemaProps via `.compute(v => v[key])`. Because `compute()` routes through `signalComputed` for stores (Phase 4a), each child is reactive to its specific path.
- **Stable child identity:** `vm.\$user.name === vm.\$user.name` (cached).
- **`instanceof SchemaProp` preserved:** Proxy keeps the target's prototype, so html templates accept the path-binding as a SchemaProp without changes.
- **ES private-field interop fix:** SchemaProp uses `#`-fields. When accessed via Proxy, `this` resolves to the proxy and `this.#signal` throws because the proxy isn't in the class's private-field slot map. Fix: in the get-trap, set `receiver = target` and `.bind(target)` methods before returning. Mirror fix in the set-trap.
- **Method-vs-data collision:** Per the locked decision in STORES.md §10.1, SchemaProp method wins. Dev-mode `console.warn` identifies the colliding key. Production builds skip the check.
- **Type system:** new `StorePathBinding<T>` type recursively mirrors T's shape on top of SchemaProp. `TypedSchemaProp<T>` resolves to `StorePathBinding<U>` when `T extends Store<infer U>`. Built-in types (Date/RegExp/Map/Set/Promise/Function) collapse to a leaf SchemaProp instead of recursing. **No `as any` casts in tests** — `vm.\$user.address.city` is typed all the way to `TypedSchemaProp<string>`.

## Trio

- `npm run type-check` → clean
- `npm run lint` → 0 errors
- `npm test` → **290/290** (280 prior + **10 new**)
- `npm run format:check` → my files clean

## Test coverage (10 new tests)

- Basic traversal, deep paths, stable child identity.
- Granularity: sibling-path mutations don't fire each other's observers.
- Composition: `.compute()` on a leaf path-binding chains correctly.
- `.peek()` doesn't track.
- **End-to-end html template:** `\${vm.\$user.name}` and `\${vm.\$data.user.profile.name}` update granularly when the store path changes.
- Method-vs-data collision warning fires in dev mode.
- No regression of plain signal-style \$-prefix access.

## Not in this PR

- **Phase 4c:** `repeat()` integration with store arrays.
- **Phase 5:** `snapshot()`, `subscribe()` + `Path<T>` types, devtools formatter, dev-mode warnings, `@rollup/plugin-replace` add.

## Targets v1.1.0

Combined with Phase 4c + 5 ships as v1.1.0.