### PR TITLE
feat: store() Phase 4c — repeat() integration with store arrays

### DIFF
--- a/__tests__/view/repeat-stores.test.ts
+++ b/__tests__/view/repeat-stores.test.ts
@@ -1,0 +1,246 @@
+import { getByTestId } from "@testing-library/dom";
+import { html, useViewModel, store, repeat } from "../../src";
+
+const TEST_ID = "repeat-store-test";
+const flush = () => new Promise<void>(resolve => queueMicrotask(resolve));
+// Two flushes: signal-effect microtask + SchemaProp.update observer microtask
+const flushTwice = async () => {
+  await flush();
+  await flush();
+};
+
+describe("repeat() + store arrays (Phase 4c)", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  describe("basic rendering", () => {
+    it("renders initial items from a store-backed array", () => {
+      const vm = useViewModel({
+        todos: store([
+          { id: 1, text: "Buy milk" },
+          { id: 2, text: "Walk dog" },
+        ]),
+      });
+
+      const view = html`
+        <ul data-testid="${TEST_ID}">
+          ${repeat(
+            vm.$todos,
+            t => t.id,
+            t => html`<li>${t.text}</li>`
+          )}
+        </ul>
+      `;
+      view.mount(document.body);
+
+      const el = getByTestId(document.body, TEST_ID);
+      const items = el.querySelectorAll("li");
+      expect(items.length).toBe(2);
+      expect(items[0].textContent).toContain("Buy milk");
+      expect(items[1].textContent).toContain("Walk dog");
+    });
+  });
+
+  describe("reactive add / remove via store mutations", () => {
+    it("push() adds a new <li> without re-creating existing nodes", async () => {
+      interface Todo {
+        id: number;
+        text: string;
+      }
+      const vm = useViewModel({
+        todos: store<Todo[]>([{ id: 1, text: "a" }]),
+      });
+
+      const view = html`
+        <ul data-testid="${TEST_ID}">
+          ${repeat(
+            vm.$todos,
+            t => t.id,
+            t => html`<li>${t.text}</li>`
+          )}
+        </ul>
+      `;
+      view.mount(document.body);
+
+      const el = getByTestId(document.body, TEST_ID);
+      const initialLi = el.querySelector("li")!;
+      expect(initialLi.textContent).toContain("a");
+
+      vm.todos.push({ id: 2, text: "b" });
+      await flushTwice();
+
+      const items = el.querySelectorAll("li");
+      expect(items.length).toBe(2);
+      expect(items[0].textContent).toContain("a");
+      expect(items[1].textContent).toContain("b");
+      // Key-stable: existing <li> is the same DOM node.
+      expect(items[0]).toBe(initialLi);
+    });
+
+    it("pop() removes the trailing <li>", async () => {
+      interface Todo {
+        id: number;
+        text: string;
+      }
+      const vm = useViewModel({
+        todos: store<Todo[]>([
+          { id: 1, text: "a" },
+          { id: 2, text: "b" },
+          { id: 3, text: "c" },
+        ]),
+      });
+
+      const view = html`
+        <ul data-testid="${TEST_ID}">
+          ${repeat(
+            vm.$todos,
+            t => t.id,
+            t => html`<li>${t.text}</li>`
+          )}
+        </ul>
+      `;
+      view.mount(document.body);
+
+      vm.todos.pop();
+      await flushTwice();
+
+      const el = getByTestId(document.body, TEST_ID);
+      expect(el.querySelectorAll("li").length).toBe(2);
+      expect(el.textContent).not.toContain("c");
+    });
+
+    it("splice() reorders and changes contents", async () => {
+      interface Todo {
+        id: number;
+        text: string;
+      }
+      const vm = useViewModel({
+        todos: store<Todo[]>([
+          { id: 1, text: "a" },
+          { id: 2, text: "b" },
+          { id: 3, text: "c" },
+        ]),
+      });
+
+      const view = html`
+        <ul data-testid="${TEST_ID}">
+          ${repeat(
+            vm.$todos,
+            t => t.id,
+            t => html`<li>${t.text}</li>`
+          )}
+        </ul>
+      `;
+      view.mount(document.body);
+
+      vm.todos.splice(1, 1, { id: 99, text: "x" });
+      await flushTwice();
+
+      const el = getByTestId(document.body, TEST_ID);
+      const items = el.querySelectorAll("li");
+      expect(items.length).toBe(3);
+      expect(items[0].textContent).toContain("a");
+      expect(items[1].textContent).toContain("x");
+      expect(items[2].textContent).toContain("c");
+    });
+  });
+
+  describe("in-place item-field edits (documented limitation)", () => {
+    // The templateFn captures item-field reads as static snapshots, not
+    // reactive bindings — `html`<li>${t.text}</li>`` interpolates the
+    // string value of `t.text` at render time. For per-field reactivity
+    // inside an item, users must opt in by interpolating a reactive
+    // SchemaProp (e.g., via a separate path-binding or .compute()).
+    //
+    // Phase 4c covers add / remove / reorder reactively, which is the
+    // primary use case. Per-field item reactivity is a candidate for a
+    // future enhancement (passing path-bound proxies to templateFn).
+    it("edits to existing item fields do NOT auto-rerender the <li>", async () => {
+      interface Todo {
+        id: number;
+        text: string;
+      }
+      const vm = useViewModel({
+        todos: store<Todo[]>([
+          { id: 1, text: "buy milk" },
+          { id: 2, text: "walk dog" },
+        ]),
+      });
+
+      const view = html`
+        <ul data-testid="${TEST_ID}">
+          ${repeat(
+            vm.$todos,
+            t => t.id,
+            t => html`<li>${t.text}</li>`
+          )}
+        </ul>
+      `;
+      view.mount(document.body);
+
+      vm.todos[0].text = "BUY MILK";
+      await flushTwice();
+
+      const el = getByTestId(document.body, TEST_ID);
+      const items = el.querySelectorAll("li");
+      // Documented behavior: <li> still shows the original text.
+      // Underlying store IS updated.
+      expect(vm.todos[0].text).toBe("BUY MILK");
+      expect(items[0].textContent).toContain("buy milk");
+    });
+  });
+
+  describe("deeply nested store arrays", () => {
+    it("vm.$data.todos works in templates", async () => {
+      interface Todo {
+        id: number;
+        text: string;
+      }
+      const vm = useViewModel({
+        data: store<{ todos: Todo[] }>({
+          todos: [{ id: 1, text: "a" }],
+        }),
+      });
+
+      const view = html`
+        <ul data-testid="${TEST_ID}">
+          ${repeat<Todo>(
+            vm.$data.todos,
+            t => t.id,
+            t => html`<li>${t.text}</li>`
+          )}
+        </ul>
+      `;
+      view.mount(document.body);
+
+      vm.data.todos.push({ id: 2, text: "b" });
+      await flushTwice();
+
+      const el = getByTestId(document.body, TEST_ID);
+      expect(el.querySelectorAll("li").length).toBe(2);
+    });
+  });
+
+  describe("existing non-store usage is unchanged", () => {
+    it("repeat() with a static array still works", () => {
+      const items = [
+        { id: 1, text: "one" },
+        { id: 2, text: "two" },
+      ];
+      const view = html`
+        <ul data-testid="${TEST_ID}">
+          ${repeat(
+            items,
+            i => i.id,
+            i => html`<li>${i.text}</li>`
+          )}
+        </ul>
+      `;
+      view.mount(document.body);
+
+      const el = getByTestId(document.body, TEST_ID);
+      expect(el.querySelectorAll("li").length).toBe(2);
+    });
+  });
+});

--- a/src/view/external/repeat.ts
+++ b/src/view/external/repeat.ts
@@ -1,5 +1,6 @@
 import { SchemaProp } from "../../schema";
 import { SchemaPropValue } from "../../schema/types";
+import { effect as signalEffect, isStore } from "../../reactivity";
 
 /**
  * Minimal structural interface for what `repeat()` needs from a SchemaProp.
@@ -124,14 +125,41 @@ export const repeat = <T>(
     keyMap = newKeyMap;
   }
 
-  // Initial render
-  reconcile(initialItems);
+  if (Array.isArray(items)) {
+    // Static array — render once, no subscription.
+    reconcile(items);
+  } else {
+    const initialValue = items.value;
 
-  // Subscribe to reactive updates if items is a SchemaProp
-  if (!Array.isArray(items)) {
-    items.observe((newValue: SchemaPropValue) => {
-      reconcile(Array.isArray(newValue) ? (newValue as T[]) : []);
-    });
+    if (Array.isArray(initialValue) && isStore(initialValue)) {
+      // Store array (Phase 4c). Inner mutations (push/pop/index assignment)
+      // don't replace the array reference, so the SchemaProp's observer chain
+      // won't fire on them — its underlying signal value (the store proxy)
+      // is unchanged by reference. Subscribe directly to the store's path-level
+      // notifications via a signal effect: reading the array's length and
+      // iterating its elements registers the effect as a subscriber to the
+      // length sentinel and every current index.
+      //
+      // NOTE: this effect is currently not disposed when the view unmounts.
+      // Container-level lifecycle hooks are tracked for Phase 5 polish.
+      signalEffect(() => {
+        const arr = items.value;
+        if (Array.isArray(arr)) {
+          // Force per-index + length subscriptions so any in-place mutation
+          // triggers reconciliation.
+          arr.forEach(() => {
+            /* dependency-tracking side effect */
+          });
+        }
+        reconcile(Array.isArray(arr) ? (arr as T[]) : []);
+      });
+    } else {
+      // Plain SchemaProp array — existing observe-based subscription.
+      reconcile(initialItems);
+      items.observe((newValue: SchemaPropValue) => {
+        reconcile(Array.isArray(newValue) ? (newValue as T[]) : []);
+      });
+    }
   }
 
   return container;


### PR DESCRIPTION
## Summary

Completes the view-layer integration trio (4a + 4b + 4c). Stores now work end-to-end across `createWidget`, `useViewModel`, `html` templates, and `repeat()`.

## Why the existing observe-chain didn't work

`SchemaProp.observe` fires when its signal's value is **replaced** (per `Object.is`). Store array mutations (push/pop/splice/index assignment) keep the same array reference — only inner paths change. So the observer chain never fires on inner mutations.

## Fix

In `src/view/external/repeat.ts`, detect store arrays at `items.value` and drive reconciliation with a real `signalEffect`. The effect reads `arr.length` and iterates via `forEach`, registering as a subscriber to every current index + length. Any in-place mutation triggers re-run via the store's path-level signal system.

Non-store paths (plain SchemaProp arrays, static arrays) keep the original byte-identical code paths — locked by 290 existing tests still passing.

## Known limitations (documented in PR; fixed in Phase 5 polish)

- The `signalEffect` isn't disposed on view unmount. Container-lifecycle hooks for cleanup are Phase 5.
- Per-item-field reactivity inside `templateFn` isn't automatic: `html\`<li>\${t.text}</li>\`` captures `t.text` as a snapshot. Add/remove/reorder is fully reactive; in-place field edits require an explicit reactive binding (or a future enhancement passing path-bound proxies to `templateFn`). One test documents the current behavior.

## Trio

- `npm run type-check` → clean
- `npm run lint` → 0 errors (49 pre-existing warnings, none in my files)
- `npm test` → **297/297** (290 prior + **7 new**)
- `npm run format:check` → my files clean

## What ships when this merges

```ts
const vm = useViewModel({ todos: store([...]) });
html\`<ul>\${repeat(vm.\$todos, t => t.id, t => html\`<li>\${t.text}</li>\`)}</ul>\`;
```

— and add/remove/reorder reactively renders.

## Not in this PR

- **Phase 5:** `snapshot()`, `subscribe()` + `Path<T>` types, devtools formatter, dev-mode warnings, `@rollup/plugin-replace` add, repeat cleanup lifecycle.