### PR TITLE
feat: store() Phase 5a — snapshot, subscribe, Path<T> types

### DIFF
--- a/__tests__/reactivity/store-snapshot-subscribe.test.ts
+++ b/__tests__/reactivity/store-snapshot-subscribe.test.ts
@@ -1,0 +1,238 @@
+import {
+  store,
+  markRaw,
+  snapshot,
+  subscribe,
+  effect,
+} from "../../src/reactivity";
+
+const flush = () => new Promise<void>(resolve => queueMicrotask(resolve));
+
+describe("snapshot() (Phase 5a)", () => {
+  describe("basic semantics", () => {
+    it("returns a deep plain-object copy", () => {
+      const s = store({ user: { name: "Alice", age: 30 }, count: 5 });
+      const snap = snapshot(s);
+      expect(snap).toEqual({ user: { name: "Alice", age: 30 }, count: 5 });
+    });
+
+    it("the snapshot is structurally T but is not a store", () => {
+      const s = store({ x: 1 });
+      const snap = snapshot(s);
+      expect(snap.x).toBe(1);
+      // It's a plain object, not a proxy.
+      expect(Object.getPrototypeOf(snap)).toBe(Object.prototype);
+    });
+
+    it("is safe to JSON.stringify (round-trips)", () => {
+      const s = store({ user: { name: "Alice" }, ids: [1, 2, 3] });
+      const json = JSON.stringify(snapshot(s));
+      expect(JSON.parse(json)).toEqual({
+        user: { name: "Alice" },
+        ids: [1, 2, 3],
+      });
+    });
+
+    it("arrays are deep-copied", () => {
+      const s = store({ list: [{ x: 1 }, { x: 2 }] });
+      const snap = snapshot(s);
+      expect(snap.list).not.toBe(s.list);
+      expect(snap.list[0]).not.toBe(s.list[0]);
+      expect(snap.list).toEqual([{ x: 1 }, { x: 2 }]);
+    });
+  });
+
+  describe("does not subscribe", () => {
+    it("snapshot inside an effect does NOT cause re-runs on store mutations", async () => {
+      const s = store({ name: "Alice" });
+      let runs = 0;
+      effect(() => {
+        snapshot(s);
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      s.name = "Bob";
+      await flush();
+      expect(runs).toBe(1);
+    });
+  });
+
+  describe("boundary rules", () => {
+    it("Date / Map / Set / class instances pass through by reference", () => {
+      class Widget {
+        n = 1;
+      }
+      const date = new Date();
+      const map = new Map();
+      const set = new Set();
+      const widget = new Widget();
+      const s = store({ date, map, set, widget });
+      const snap = snapshot(s);
+      expect(snap.date).toBe(date);
+      expect(snap.map).toBe(map);
+      expect(snap.set).toBe(set);
+      expect(snap.widget).toBe(widget);
+    });
+
+    it("markRaw'd values pass through by reference", () => {
+      const blob = markRaw({ deeply: { nested: { value: 42 } } });
+      const s = store({ payload: blob });
+      const snap = snapshot(s);
+      expect(snap.payload).toBe(blob);
+    });
+  });
+
+  describe("cycles", () => {
+    it("handles cyclic data without stack-overflowing", () => {
+      interface Node {
+        name: string;
+        self?: Node;
+      }
+      const raw: Node = { name: "root" };
+      raw.self = raw;
+      const s = store(raw);
+      // Should not throw.
+      const snap = snapshot(s);
+      expect(snap.name).toBe("root");
+      expect(snap.self).toBe(snap); // cycle preserved in the snapshot
+    });
+  });
+});
+
+describe("subscribe() (Phase 5a)", () => {
+  describe("path subscriptions", () => {
+    it("fires on changes to the exact path", async () => {
+      const s = store({ user: { name: "Alice", age: 30 } });
+      const events: Array<[string | undefined, string | undefined]> = [];
+      const off = subscribe(s, "user.name", (next, prev) => {
+        events.push([next, prev]);
+      });
+
+      s.user.name = "Bob";
+      await flush();
+      expect(events).toEqual([["Bob", "Alice"]]);
+
+      s.user.name = "Carol";
+      await flush();
+      expect(events).toEqual([
+        ["Bob", "Alice"],
+        ["Carol", "Bob"],
+      ]);
+      off();
+    });
+
+    it("does NOT fire on unrelated path changes", async () => {
+      const s = store({ user: { name: "Alice", age: 30 } });
+      let fired = 0;
+      const off = subscribe(s, "user.name", () => {
+        fired++;
+      });
+
+      s.user.age = 31;
+      await flush();
+      expect(fired).toBe(0);
+      off();
+    });
+
+    it("works for deeply-nested paths", async () => {
+      interface State {
+        data: { user: { profile: { city: string } } };
+      }
+      const s = store<State>({ data: { user: { profile: { city: "NYC" } } } });
+      let received: unknown = null;
+      const off = subscribe(s, "data.user.profile.city", next => {
+        received = next;
+      });
+
+      s.data.user.profile.city = "SF";
+      await flush();
+      expect(received).toBe("SF");
+      off();
+    });
+
+    it("array index paths work (e.g. 'items.0.x')", async () => {
+      interface State {
+        items: Array<{ x: number }>;
+      }
+      const s = store<State>({ items: [{ x: 1 }, { x: 2 }] });
+      let received: unknown = null;
+      const off = subscribe(s, "items.0.x", next => {
+        received = next;
+      });
+
+      s.items[0].x = 99;
+      await flush();
+      expect(received).toBe(99);
+      off();
+    });
+  });
+
+  describe('whole-store subscription via path=""', () => {
+    it("fires on any mutation anywhere in the store", async () => {
+      const s = store({ user: { name: "Alice" }, count: 0 });
+      const events: number[] = [];
+      const off = subscribe(s, "", () => {
+        events.push(events.length);
+      });
+
+      s.user.name = "Bob";
+      await flush();
+      s.count = 5;
+      await flush();
+      expect(events.length).toBe(2);
+      off();
+    });
+
+    it("receives whole-store snapshot values", async () => {
+      const s = store({ count: 0 });
+      let snap: { count: number } | null = null;
+      const off = subscribe(s, "", next => {
+        snap = next;
+      });
+
+      s.count = 42;
+      await flush();
+      expect(snap).toEqual({ count: 42 });
+      // Snapshots are plain objects, not proxies
+      expect(Object.getPrototypeOf(snap!)).toBe(Object.prototype);
+      off();
+    });
+  });
+
+  describe("unsubscribe", () => {
+    it("the returned dispose function stops further callbacks", async () => {
+      const s = store({ x: 0 });
+      let fired = 0;
+      const off = subscribe(s, "x", () => {
+        fired++;
+      });
+
+      s.x = 1;
+      await flush();
+      expect(fired).toBe(1);
+
+      off();
+      s.x = 2;
+      await flush();
+      expect(fired).toBe(1);
+    });
+  });
+
+  describe("type safety (compile-time)", () => {
+    it("typed path narrows callback's value parameter", () => {
+      const s = store({ user: { name: "Alice", age: 30 } });
+      subscribe(s, "user.name", next => {
+        // TS should narrow `next` to string at this line.
+        const x: string = next;
+        expect(typeof x).toBe("string");
+      });
+      subscribe(s, "user.age", next => {
+        const x: number = next;
+        expect(typeof x).toBe("number");
+      });
+      // Invalid path would be a type error at the call site (see ts-expect-error
+      // assertions in dedicated type tests if added later).
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,12 @@ export { createWidget } from "./widget/createWidget";
 export { signal, computed, effect, batch, untracked } from "./reactivity";
 export type { Signal, ReadonlySignal } from "./reactivity";
 
-export { store, markRaw, isStore, unwrap } from "./reactivity";
-export type { Store } from "./reactivity";
+export {
+  store,
+  markRaw,
+  isStore,
+  unwrap,
+  snapshot,
+  subscribe,
+} from "./reactivity";
+export type { Store, Path, PathValue } from "./reactivity";

--- a/src/reactivity/index.ts
+++ b/src/reactivity/index.ts
@@ -1,5 +1,5 @@
 export { signal, computed, effect, batch, untracked } from "./signal";
 export type { Signal, ReadonlySignal } from "./signal";
 
-export { store, markRaw, isStore, unwrap } from "./store";
-export type { Store } from "./store";
+export { store, markRaw, isStore, unwrap, snapshot, subscribe } from "./store";
+export type { Store, Path, PathValue } from "./store";

--- a/src/reactivity/store.ts
+++ b/src/reactivity/store.ts
@@ -17,6 +17,8 @@ import {
   _track,
   _notify,
   batch,
+  effect as signalEffect,
+  untracked,
 } from "./signal";
 
 // ---------------------------------------------------------------------------
@@ -348,4 +350,180 @@ export function unwrap<T extends object>(value: Store<T> | T): T {
     return (value as unknown as Record<symbol, unknown>)[$RAW] as T;
   }
   return value as T;
+}
+
+// ---------------------------------------------------------------------------
+// snapshot() — deep plain-object copy
+// ---------------------------------------------------------------------------
+
+/**
+ * Deep-clone a store to a plain object. Returned value is structurally `T`,
+ * contains no reactivity, and is safe to `JSON.stringify`, structurally
+ * compare, or hand to non-reactive code.
+ *
+ * Reading via `snapshot()` does **not** register reactive subscriptions —
+ * it's a non-tracking deep read suitable for use outside reactive contexts.
+ * If you call it inside an `effect`, the effect will not re-run on store
+ * mutations.
+ *
+ * Built-in values (Date, Map, Set, RegExp, class instances, etc.) are
+ * returned by reference — only plain objects and arrays are deep-copied.
+ *
+ * @example
+ * ```ts
+ * const state = store({ user: { name: "Alice" }, todos: [1, 2, 3] });
+ * const json = JSON.stringify(snapshot(state));
+ * ```
+ */
+export function snapshot<T extends object>(s: Store<T>): T {
+  // Walk through the proxy so cycles + nested stores resolve correctly, but
+  // wrap in `untracked()` so the user-facing contract holds: snapshot() never
+  // registers reactive subscriptions, even when called inside an effect.
+  return untracked(() => cloneDeep(s, new WeakMap())) as T;
+}
+
+function cloneDeep(value: unknown, seen: WeakMap<object, object>): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (!shouldProxy(value)) return value; // pass built-ins/markRaw by reference
+  const existing = seen.get(value);
+  if (existing) return existing; // cycle
+  if (Array.isArray(value)) {
+    const out: unknown[] = [];
+    seen.set(value, out);
+    for (let i = 0; i < value.length; i++) {
+      out[i] = cloneDeep(value[i], seen);
+    }
+    return out;
+  }
+  const out: Record<string, unknown> = {};
+  seen.set(value, out);
+  for (const k of Object.keys(value)) {
+    out[k] = cloneDeep((value as Record<string, unknown>)[k], seen);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Path<T> / PathValue<T, P> — typed dotted-string paths
+//
+// Pattern from STORE_RESEARCH_FINDINGS.md §8 (type-fest / react-hook-form
+// heritage). Depth-capped recursion via tuple-length decrement; pure type-level,
+// zero runtime cost.
+// ---------------------------------------------------------------------------
+
+type PathPrimitive =
+  | string
+  | number
+  | boolean
+  | bigint
+  | symbol
+  | null
+  | undefined;
+// Treat these as path leaves — don't recurse into them.
+type PathLeafObject =
+  | Date
+  | RegExp
+  | Map<unknown, unknown>
+  | Set<unknown>
+  | Promise<unknown>
+  | ((...args: unknown[]) => unknown);
+type PathBuiltin = PathPrimitive | PathLeafObject;
+type PrevDepth = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+/** Union of all dotted paths through T, depth-capped (default 10). */
+export type Path<T, D extends number = 10> = [D] extends [never]
+  ? never
+  : T extends PathBuiltin
+    ? never
+    : T extends ReadonlyArray<infer U>
+      ? `${number}` | `${number}.${Path<U, PrevDepth[D]>}`
+      : T extends object
+        ? {
+            [K in keyof T & (string | number)]: T[K] extends PathBuiltin
+              ? `${K}`
+              : `${K}` | `${K}.${Path<NonNullable<T[K]>, PrevDepth[D]>}`;
+          }[keyof T & (string | number)]
+        : never;
+
+/** Value type at path P within T. Propagates `| undefined` if any segment is optional. */
+export type PathValue<T, P extends string> = P extends `${infer K}.${infer R}`
+  ? K extends keyof NonNullable<T>
+    ?
+        | PathValue<NonNullable<T>[K], R>
+        | (undefined extends T ? undefined : never)
+    : NonNullable<T> extends ReadonlyArray<infer U>
+      ? PathValue<U, R> | (undefined extends T ? undefined : never)
+      : never
+  : P extends keyof NonNullable<T>
+    ? NonNullable<T>[P] | (undefined extends T ? undefined : never)
+    : NonNullable<T> extends ReadonlyArray<infer U>
+      ? U | (undefined extends T ? undefined : never)
+      : never;
+
+// ---------------------------------------------------------------------------
+// subscribe() — typed-path escape hatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Subscribe to changes at a typed dotted path within a store. Prefer
+ * `effect()` for almost everything — `subscribe()` exists for interop with
+ * non-reactive code (DOM event sinks, third-party libraries that take
+ * callbacks).
+ *
+ * Pass `""` as the path to subscribe to any change anywhere in the store —
+ * callback receives the whole-store value (as a snapshot). For finer-grained
+ * whole-store work, write an `effect()` instead.
+ *
+ * Returns an unsubscribe function. Always call it during cleanup to avoid
+ * leaking the underlying signal effect.
+ *
+ * @example
+ * ```ts
+ * const state = store({ user: { name: "Alice" } });
+ * const off = subscribe(state, "user.name", (next, prev) => {
+ *   console.log("name changed:", prev, "→", next);
+ * });
+ * state.user.name = "Bob"; // logs "name changed: Alice → Bob"
+ * off();
+ * ```
+ */
+export function subscribe<T extends object, P extends Path<T> | "">(
+  s: Store<T>,
+  path: P,
+  callback: P extends ""
+    ? (newValue: T, oldValue: T) => void
+    : (newValue: PathValue<T, P>, oldValue: PathValue<T, P>) => void
+): () => void {
+  let prev: unknown;
+  let initialized = false;
+
+  return signalEffect(() => {
+    let cur: unknown;
+    if (path === "") {
+      // Whole-store subscription: deep-walk through the proxy so every
+      // accessed path registers as a dependency of this effect. Return a
+      // snapshot-shaped value to the callback. (We deliberately do NOT use
+      // snapshot() here because its public contract is "no tracking" via
+      // untracked() — which is exactly what we want to opt OUT of.)
+      cur = cloneDeep(s, new WeakMap());
+    } else {
+      cur = readPath(s, path as string);
+    }
+    if (initialized) {
+      (callback as (newVal: unknown, oldVal: unknown) => void)(cur, prev);
+    }
+    prev = cur;
+    initialized = true;
+  });
+}
+
+function readPath(s: object, path: string): unknown {
+  if (!path) return s;
+  const parts = path.split(".");
+  let cur: unknown = s;
+  for (const p of parts) {
+    if (cur === null || cur === undefined) return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
 }


### PR DESCRIPTION
## Summary

Adds the inspect / escape-hatch APIs promised by STORES.md §4.2–4.3.

- **`snapshot(store)`** — deep plain-object clone, structurally `T`. Walks through the proxy to resolve cycles + nested stores, wrapped in `untracked()` so it never registers subscriptions even inside an effect. Built-ins (Date / Map / Set / class instances) and `markRaw`'d values pass through by reference.
- **`subscribe(store, path, callback)`** — typed-path escape hatch. `subscribe(s, "user.name", cb)` types `cb`'s args as `(newVal: string, oldVal: string)`. Passing `""` subscribes to any change anywhere (callback receives whole-store snapshots). Returns unsubscribe.
- **`Path<T>` / `PathValue<T, P>`** — pure type-level helpers (zero runtime cost). Depth-capped recursion (default 10). Built-ins treated as leaves. Arrays use dot-numeric (`"items.0.x"`).

## Implementation notes

- `subscribe` for `""` deep-walks through the proxy directly rather than reusing `snapshot()` — `snapshot()`'s `untracked()` wrap would defeat the subscription. The deep-walk uses the same `cloneDeep` helper but in a tracking context.
- Types use the type-fest / react-hook-form pattern from STORE_RESEARCH_FINDINGS.md §8.

## Trio

- `npm run type-check` → clean (no casts in tests)
- `npm run lint` → 0 errors
- `npm test` → **313/313** (297 prior + **16 new**)
- `npm run format:check` → clean

## Test coverage (16 new tests)

- `snapshot`: deep copy, structural equality, JSON round-trip, array deep-copy, no-tracking inside effects, built-in / markRaw passthrough, cycle handling.
- `subscribe`: path-scoped firing, isolation from unrelated paths, deep paths, array-index paths, whole-store `""` with snapshot values, unsubscribe, compile-time type narrowing.

## Not in this PR (rest of Phase 5)

- **5b:** devtools formatter + dev-mode warnings + `@rollup/plugin-replace`
- **5c:** `repeat()` container lifecycle cleanup