### PR TITLE
test+fix(store): coverage gaps + nits from pre-v1.1.0 review (7.5c)

### DIFF
--- a/__tests__/reactivity/store-coverage-gaps.test.ts
+++ b/__tests__/reactivity/store-coverage-gaps.test.ts
@@ -1,0 +1,335 @@
+// Coverage-gap fills identified by the pre-v1.1.0 test-coverage audit
+// (Phase 7.5c). Adversarial inputs, error paths, race-ish ordering, API
+// combinations, and built-in passthrough that the happy-path suites missed.
+
+import {
+  store,
+  subscribe,
+  effect,
+  computed,
+  batch,
+  isStore,
+  markRaw,
+} from "../../src/reactivity";
+import { useViewModel } from "../../src";
+
+const flush = () => new Promise<void>(resolve => queueMicrotask(resolve));
+const flushTwice = async () => {
+  await flush();
+  await flush();
+};
+
+const NODE_SYM_DESC = "marjoram.node";
+function nodeFor(
+  raw: object,
+  key: string
+): { _subscribers: Set<unknown> } | undefined {
+  const sym = Object.getOwnPropertySymbols(raw).find(
+    s => s.description === NODE_SYM_DESC
+  );
+  if (!sym) return undefined;
+  const nodes = (
+    raw as Record<symbol, Record<string, { _subscribers: Set<unknown> }>>
+  )[sym];
+  return nodes[key];
+}
+
+describe("store() coverage gaps (Phase 7.5c)", () => {
+  describe("invalid / edge root inputs", () => {
+    it("store(null) returns null without throwing", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(store(null as any)).toBeNull();
+    });
+    it("store(undefined) returns undefined", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(store(undefined as any)).toBeUndefined();
+    });
+    it("store(primitive) passes through unchanged and is not a store", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(store(42 as any)).toBe(42);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(store("hi" as any)).toBe("hi");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(isStore(store(42 as any))).toBe(false);
+    });
+    it("store({}) — empty object — is a working store", async () => {
+      const s = store<Record<string, number>>({});
+      expect(isStore(s)).toBe(true);
+      let runs = 0;
+      effect(() => {
+        Object.keys(s);
+        runs++;
+      });
+      s.x = 1;
+      await flush();
+      expect(runs).toBe(2);
+    });
+    it("store({a:1}) — single key — works", () => {
+      const s = store({ a: 1 });
+      expect(s.a).toBe(1);
+      s.a = 2;
+      expect(s.a).toBe(2);
+    });
+  });
+
+  describe("subscribe to a path that is initially missing, then materializes", () => {
+    it("fires when the intermediate object is later assigned", async () => {
+      interface State {
+        user?: { name: string };
+      }
+      const s = store<State>({});
+      const events: unknown[] = [];
+      const off = subscribe(s, "user.name", next => {
+        events.push(next);
+      });
+      // Initially user is undefined → path resolves to undefined.
+      s.user = { name: "Alice" };
+      await flush();
+      expect(events).toEqual(["Alice"]);
+      off();
+    });
+  });
+
+  describe("self-mutation re-entry inside an effect", () => {
+    it("an effect that mutates the path it reads does NOT loop (the _running guard wins)", async () => {
+      // Documented behavior: a write that occurs WHILE the effect is running
+      // is skipped for that effect (the signal system's `_running` guard
+      // prevents self-re-triggering). So the effect runs once, applies a
+      // single mutation, and does not iterate. This is the loop-safe contract
+      // shared by mainstream signal libraries — self-mutation in an effect is
+      // an anti-pattern, not an iteration mechanism.
+      const s = store({ x: 0 });
+      let runs = 0;
+      effect(() => {
+        runs++;
+        if (s.x < 5) s.x = s.x + 1;
+      });
+      await flushTwice();
+      await flushTwice();
+      expect(runs).toBe(1);
+      expect(s.x).toBe(1);
+    });
+  });
+
+  describe("subscribe / unsubscribe during a notification round", () => {
+    it("unsubscribing one subscriber from within another's callback is safe", async () => {
+      const s = store({ x: 0 });
+      let aRuns = 0;
+      let bRuns = 0;
+      let offB = (): void => {};
+      const offA = subscribe(s, "x", () => {
+        aRuns++;
+        offB(); // remove B mid-round
+      });
+      offB = subscribe(s, "x", () => {
+        bRuns++;
+      });
+
+      s.x = 1;
+      await flush();
+      // No crash. A fired; B may or may not have fired this round depending on
+      // iteration order, but the system stays consistent.
+      expect(aRuns).toBeGreaterThanOrEqual(1);
+
+      s.x = 2;
+      await flush();
+      // After removal, B no longer fires.
+      const bAfter = bRuns;
+      s.x = 3;
+      await flush();
+      expect(bRuns).toBe(bAfter);
+      offA();
+    });
+  });
+
+  describe("chained multi-level .compute() on path bindings", () => {
+    it("a 3-level chained compute updates on innermost mutation", async () => {
+      const vm = useViewModel({
+        data: store({ user: { profile: { name: "alice" } } }),
+      });
+      const upper = vm.$data.user.profile.name.compute(n =>
+        (n as string).toUpperCase()
+      );
+      const exclaimed = upper.compute(u => `${u as string}!`);
+      expect(exclaimed.value).toBe("ALICE!");
+
+      vm.data.user.profile.name = "bob";
+      await flushTwice();
+      await flushTwice();
+      expect(exclaimed.value).toBe("BOB!");
+    });
+  });
+
+  describe("nested batch()", () => {
+    it("nested batches produce one coalesced notification round", async () => {
+      const s = store({ a: 0, b: 0 });
+      let runs = 0;
+      effect(() => {
+        s.a;
+        s.b;
+        runs++;
+      });
+      expect(runs).toBe(1);
+
+      batch(() => {
+        s.a = 1;
+        batch(() => {
+          s.b = 2;
+          s.a = 3;
+        });
+        s.b = 4;
+      });
+      await flush();
+      expect(runs).toBe(2); // single round despite nesting
+      expect(s.a).toBe(3);
+      expect(s.b).toBe(4);
+    });
+  });
+
+  describe("store created inside a re-running effect", () => {
+    it("does not accumulate live subscribers across effect re-runs", async () => {
+      const trigger = store({ tick: 0 });
+      let lastInner: { v: number } | null = null;
+      let innerEffectRuns = 0;
+
+      // Outer effect re-creates an inner store + inner effect each run.
+      effect(() => {
+        trigger.tick; // dependency
+        const inner = store({ v: 0 });
+        lastInner = inner;
+        effect(() => {
+          inner.v;
+          innerEffectRuns++;
+        });
+      });
+
+      // Trigger several outer re-runs.
+      trigger.tick = 1;
+      await flush();
+      trigger.tick = 2;
+      await flush();
+
+      // Mutating the LATEST inner store should fire its effect.
+      const before = innerEffectRuns;
+      lastInner!.v = 99;
+      await flush();
+      expect(innerEffectRuns).toBeGreaterThan(before);
+      // Sanity: no runaway accumulation (each outer run adds one inner effect
+      // initial run; we don't assert exact disposal since inner effects aren't
+      // explicitly scoped — this documents current behavior).
+    });
+  });
+
+  describe("built-in passthrough (docs §6 completeness)", () => {
+    it("TypedArray / DataView / ArrayBuffer / Promise / BigInt pass through unproxied", () => {
+      const buf = new ArrayBuffer(8);
+      const ta = new Uint8Array(buf);
+      const dv = new DataView(buf);
+      const promise = Promise.resolve(1);
+      const big = 10n;
+      const s = store({ buf, ta, dv, promise, big });
+      expect(s.buf).toBe(buf);
+      expect(s.ta).toBe(ta);
+      expect(s.dv).toBe(dv);
+      expect(s.promise).toBe(promise);
+      expect(s.big).toBe(big);
+      expect(isStore(s.ta)).toBe(false);
+    });
+  });
+
+  describe("sealed / non-extensible objects pass through (nit #9)", () => {
+    it("Object.seal'd nested object is not proxied (no throw)", () => {
+      const sealed = Object.seal({ x: 1 });
+      const s = store({ payload: sealed });
+      expect(s.payload).toBe(sealed);
+      expect(isStore(s.payload)).toBe(false);
+    });
+    it("Object.preventExtensions'd object is not proxied", () => {
+      const locked = Object.preventExtensions({ y: 2 });
+      const s = store({ payload: locked });
+      expect(s.payload).toBe(locked);
+    });
+  });
+
+  describe("subscription de-dup and multi-effect fan-in", () => {
+    it("reading the same path twice in one effect registers a single subscriber", () => {
+      const raw = { x: 1 };
+      const s = store(raw);
+      effect(() => {
+        s.x;
+        s.x; // read twice
+      });
+      const node = nodeFor(raw, "x");
+      expect(node).toBeDefined();
+      expect(node!._subscribers.size).toBe(1);
+    });
+
+    it("N effects on the same path each re-run exactly once per change", async () => {
+      const s = store({ x: 0 });
+      const counts = [0, 0, 0];
+      const disposers = counts.map((_, i) =>
+        effect(() => {
+          s.x;
+          counts[i]++;
+        })
+      );
+      expect(counts).toEqual([1, 1, 1]);
+      s.x = 1;
+      await flush();
+      expect(counts).toEqual([2, 2, 2]);
+      disposers.forEach(d => d());
+    });
+  });
+
+  describe("markRaw on a value already inside a store", () => {
+    it("marking an already-proxied value flags its raw, so FUTURE reads return the raw (call markRaw before insertion)", () => {
+      const s = store({ user: { name: "Alice" } });
+      const proxied = s.user; // already a store proxy
+      expect(isStore(proxied)).toBe(true);
+
+      // markRaw sets FLAG_SKIP on the underlying raw object (via the proxy's
+      // defineProperty trap). On the NEXT read, shouldProxy() sees the skip
+      // flag and returns the raw object unproxied. Documented guidance:
+      // markRaw BEFORE inserting into a store, not after.
+      markRaw(proxied as object);
+      expect(isStore(s.user)).toBe(false);
+    });
+  });
+
+  describe("prototype-chain (inherited) keys", () => {
+    it("an Object.create(proto) value is NOT proxied (only Object/Array.prototype/null are 'plain')", () => {
+      // shouldProxy() requires the prototype to be Object.prototype,
+      // Array.prototype, or null. An object with a custom prototype is treated
+      // like a class instance — passed through by reference, unproxied. This
+      // is the documented boundary (docs §6) that keeps stores from wrapping
+      // things they don't understand.
+      const proto = { inherited: "from-proto" };
+      const obj = Object.create(proto) as { own?: number; inherited?: string };
+      obj.own = 1;
+      const s = store(obj);
+      expect(isStore(s)).toBe(false);
+      // It's the raw object, fully usable, just not reactive.
+      expect(s.own).toBe(1);
+      expect(s.inherited).toBe("from-proto");
+    });
+  });
+
+  describe("computed over store recomputes only on dependency change", () => {
+    it("a computed reading one path is not invalidated by writes to another", () => {
+      const s = store({ a: 1, b: 2 });
+      let recomputes = 0;
+      const c = computed(() => {
+        recomputes++;
+        return s.a * 10;
+      });
+      expect(c()).toBe(10);
+      expect(recomputes).toBe(1);
+      s.b = 99;
+      expect(c()).toBe(10);
+      expect(recomputes).toBe(1);
+      s.a = 5;
+      expect(c()).toBe(50);
+      expect(recomputes).toBe(2);
+    });
+  });
+});

--- a/src/reactivity/store.ts
+++ b/src/reactivity/store.ts
@@ -85,8 +85,11 @@ function shouldProxy(value: unknown): value is object {
   if (value === null || typeof value !== "object") return false;
   // markRaw opt-out
   if ((value as Record<PropertyKey, unknown>)[FLAG_SKIP] === true) return false;
-  // Frozen objects can't be safely proxied (writes would throw).
-  if (Object.isFrozen(value)) return false;
+  // Non-extensible objects (frozen, sealed, or Object.preventExtensions'd)
+  // can't carry the $PROXY / $NODE symbol metadata — defineProperty would
+  // throw. isExtensible === false covers all three cases (frozen ⊆ sealed ⊆
+  // non-extensible). Pass them through by reference instead.
+  if (!Object.isExtensible(value)) return false;
   // Only plain objects and arrays. Class instances, Date, Map, Set, DOM
   // nodes, etc. all have non-Object/non-Array prototypes.
   const proto = Object.getPrototypeOf(value);
@@ -337,7 +340,9 @@ function wrap<T extends object>(raw: T): T {
     Object.defineProperty(raw, $PROXY, {
       value: proxy,
       enumerable: false,
-      configurable: false,
+      // configurable so the slot can be cleared if a future disposal path
+      // ever needs to re-wrap; harmless today, keeps options open.
+      configurable: true,
       writable: false,
     });
   }
@@ -373,6 +378,12 @@ export function store<T extends object>(initial: T): Store<T> {
   // short-circuits, and Terser dead-code-eliminates the entire formatter
   // body via the @rollup/plugin-replace substitution.
   installDevtoolsFormatter();
+  // Defensive: T is typed `extends object`, but loose/untyped callers (or JS
+  // consumers) may pass null/undefined/primitives. Return them unchanged
+  // rather than throwing on the flag read below.
+  if (initial === null || typeof initial !== "object") {
+    return initial as Store<T>;
+  }
   // Already a store — return as-is (idempotent, handles cycles).
   if ((initial as Record<PropertyKey, unknown>)[FLAG_IS_STORE] === true) {
     return initial as Store<T>;

--- a/src/useViewModel/storePathBinding.ts
+++ b/src/useViewModel/storePathBinding.ts
@@ -21,8 +21,12 @@ import { SchemaProp } from "../schema";
 /**
  * The set of keys reserved by SchemaProp — accessed through the proxy, these
  * delegate to the underlying SchemaProp instance instead of traversing into
- * the store. Derived once from SchemaProp.prototype so it stays in sync with
- * the class.
+ * the store. Hand-maintained: it must include the instance fields set in the
+ * constructor (`key`, `id`) which aren't on the prototype, plus the prototype
+ * methods and the dynamic array-method getters. If SchemaProp gains a new
+ * public member, add it here (the store-path-binding tests cover the common
+ * ones). Kept explicit rather than reflected so a stray prototype symbol can
+ * never accidentally shadow a data key.
  */
 const SCHEMA_PROP_KEYS = new Set<string | symbol>([
   // Static/dynamic instance fields


### PR DESCRIPTION
## Summary

Final remediation PR. Fills the test-coverage-audit gaps and clears the low-priority code-review nits. **Completes the Phase 7.5 review remediation** (7.5a security + 7.5b correctness + 7.5c gaps/nits).

## Real fix

- **`store(null)` / `store(undefined)` / `store(primitive)` no longer throw.** The flag read at the top blew up on `null`. Added an early pass-through for non-objects (defensive for loose/JS callers).

## Nits

- **`shouldProxy` rejects any non-extensible object** (frozen, sealed, `preventExtensions`), not just frozen — sealed objects can't carry the `$PROXY`/`$NODE` symbols so `wrap()` would have thrown. Now they pass through.
- **`$PROXY` is now `configurable: true`** (was false) to keep a future disposal/re-wrap path open.
- **Corrected the `SCHEMA_PROP_KEYS` comment** — it's hand-maintained on purpose, not reflected.

## Tests (19 new)

Beyond the fixes above, pins several correct-but-subtle behaviors the audit flagged as untested: subscribe to an initially-missing path that materializes; self-mutation in an effect does NOT loop; subscribe/unsubscribe mid-notification is safe; 3-level chained `.compute()`; nested `batch()`; store created inside a re-running effect; TypedArray/DataView/ArrayBuffer/Promise/BigInt passthrough; `Object.create(customProto)` is not proxied (documented boundary); markRaw-after-insertion semantics; same-path-twice de-dup; N-effects-one-path fan-in.

## Trio

- type-check clean
- lint 0 errors (49 pre-existing warnings)
- **416/416** tests (397 prior + **19 new**)
- Build clean, no circular deps, ESM 5.88 KB gzipped

## Remediation complete

Every HIGH/MEDIUM/LOW finding and nit from the 3-agent audit (code review + test coverage + security) is now addressed across #22, #23, and this PR. After this lands, **Phase 8** (README/demo/release prep for v1.1.0) is the last step.