### PR TITLE
docs: v1.1.0 — store() README, demo, changelog (Phase 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to Marjoram are documented here. This project follows
+[Semantic Versioning](https://semver.org/).
+
+## [1.1.0] — 2026-05-29
+
+Additive, non-breaking. Adds deep reactivity as a peer to `signal()`. No
+existing API changed; all 1.0.0 code continues to work unchanged.
+
+### Added
+
+- **`store(initial)`** — deeply-reactive, path-granular state. Mutate nested
+  paths directly (`state.user.address.city = "x"`) and only subscribers to
+  that exact path re-run. Built on the existing signal graph; integrates with
+  `computed`, `effect`, `batch`, and `untracked` with no new reactivity system.
+- **Path-binding in templates** — `vm.$store.path.to.leaf` is a reactive
+  binding to a specific store path, typed all the way to the leaf.
+- **`repeat()` + store arrays** — `push`/`pop`/`splice`/`sort`/etc. reconcile
+  a keyed list reactively; mutating array methods coalesce into one
+  notification round.
+- **`snapshot(store)`** — deep plain-object copy (safe to `JSON.stringify`).
+- **`subscribe(store, path, cb)`** — typed-path escape hatch; `Path<T>` /
+  `PathValue<T, P>` resolve dotted paths at compile time.
+- **`markRaw(value)`** — opt a value out of being proxied.
+- **`isStore(value)` / `unwrap(store)`** — type guard and raw-object accessor.
+- **DevTools custom formatter** — stores render as `Store { … }` in the
+  console (dev builds only; stripped from production).
+- **`repeat` and `when`** are now explicit named exports (previously reachable
+  only through `export *`).
+
+### Security
+
+- Internal store flags are `Symbol`s, so untrusted JSON cannot spoof store
+  identity or escape reactivity.
+- Prototype-pollution and prototype-chain exfiltration guards: `__proto__` /
+  `constructor` / `prototype` are not writable or traversable through a store
+  proxy or a `subscribe()` path.
+- `markRaw()` throws on built-in prototypes (`Object`/`Array`/`Function`).
+
+### Notes
+
+- Bundle: ~5.9 KB gzipped (ESM), zero runtime dependencies. The DevTools
+  formatter is dead-code-eliminated from production builds.
+- `store()` is opt-in; `useViewModel` does not auto-wrap nested plain objects.
+- Full contract and gotchas: [docs/STORES.md](docs/STORES.md).
+
+## [1.0.0] — 2026-03-15
+
+Initial release: `createWidget`, `html`, `useViewModel`, `signal`, `computed`,
+`effect`, `batch`, `untracked`, `when`, `repeat`, Shadow DOM isolation,
+XSS-safe templating.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Build self-contained widgets — chat launchers, cookie banners, feedback forms,
 ## Table of Contents
 
 - [🚀 Quick Start](#quick-start) - Build and mount a widget in 30 seconds
-- [📖 API Reference](#api-reference) - `createWidget`, `html`, `useViewModel`, `repeat`, `when`
+- [📖 API Reference](#api-reference) - `createWidget`, `html`, `useViewModel`, `store`, `repeat`, `when`
 - [💡 Examples](#examples) - Todo app, forms, data fetching
-- [🎯 TypeScript Support](#typescript-support) - Type safety and IntelliSense  
+- [🎯 TypeScript Support](#typescript-support) - Type safety and IntelliSense
 - [🧬 Reactivity](#reactivity) - Signals, computed, and effects
 - [⚡ Performance](#performance) - Real benchmarks with hard numbers
 - [⚠️ Current Limitations](#current-limitations) - Known constraints and workarounds
@@ -48,20 +48,20 @@ npm install marjoram
 ### Your First Widget
 
 ```typescript
-import { createWidget, html } from 'marjoram';
+import { createWidget, html } from "marjoram";
 
 const widget = createWidget({
-  target: '#my-widget',
-  shadow: 'closed',               // Style-isolated from host page
+  target: "#my-widget",
+  shadow: "closed", // Style-isolated from host page
   styles: `
     .counter { font-family: system-ui; padding: 1rem; }
     button { cursor: pointer; padding: 0.25rem 0.75rem; }
   `,
   model: {
     count: 0,
-    doubled: (vm) => vm.count * 2, // Computed property
+    doubled: vm => vm.count * 2, // Computed property
   },
-  render: (vm) => html`
+  render: vm => html`
     <div class="counter">
       <p>Count: ${vm.$count} (doubled: ${vm.$doubled})</p>
       <button onclick=${() => vm.count++}>+</button>
@@ -85,25 +85,25 @@ widget.mount();
 The primary entry point. Creates a self-contained, mountable widget with full lifecycle management.
 
 ```typescript
-function createWidget<T>(options: WidgetOptions<T>): Widget<T>
+function createWidget<T>(options: WidgetOptions<T>): Widget<T>;
 ```
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `target` | `Element \| string` | DOM element or CSS selector to mount into |
-| `shadow` | `'open' \| 'closed'` | Shadow DOM mode for style isolation (optional) |
-| `styles` | `string` | CSS injected alongside the view; scoped automatically with shadow DOM (optional) |
-| `model` | `object` | Initial reactive state. Functions become computed properties. |
-| `render` | `(vm) => View` | Returns the widget's view given the reactive view model |
-| `onMount` | `(vm, refs) => void` | Called after DOM insertion (optional) |
-| `onDestroy` | `(vm) => void` | Called before teardown (optional) |
+| Option      | Type                 | Description                                                                      |
+| ----------- | -------------------- | -------------------------------------------------------------------------------- |
+| `target`    | `Element \| string`  | DOM element or CSS selector to mount into                                        |
+| `shadow`    | `'open' \| 'closed'` | Shadow DOM mode for style isolation (optional)                                   |
+| `styles`    | `string`             | CSS injected alongside the view; scoped automatically with shadow DOM (optional) |
+| `model`     | `object`             | Initial reactive state. Functions become computed properties.                    |
+| `render`    | `(vm) => View`       | Returns the widget's view given the reactive view model                          |
+| `onMount`   | `(vm, refs) => void` | Called after DOM insertion (optional)                                            |
+| `onDestroy` | `(vm) => void`       | Called before teardown (optional)                                                |
 
 **Returns:** `{ mount(), destroy(), vm }`
 
 ```typescript
 const widget = createWidget({
-  target: '#chat-root',
-  shadow: 'closed',
+  target: "#chat-root",
+  shadow: "closed",
   styles: `
     .chat { position: fixed; bottom: 1rem; right: 1rem; }
     .chat__panel { display: none; }
@@ -112,22 +112,26 @@ const widget = createWidget({
   model: {
     open: false,
     messages: [] as string[],
-    unreadCount: (vm) => vm.messages.length,
+    unreadCount: vm => vm.messages.length,
   },
-  render: (vm) => html`
+  render: vm => html`
     <div class="chat">
       <button onclick=${() => (vm.open = !vm.open)}>
-        💬 ${vm.$unreadCount.compute(n => (n > 0 ? `(${n})` : ''))}
+        💬 ${vm.$unreadCount.compute(n => (n > 0 ? `(${n})` : ""))}
       </button>
-      <div class="chat__panel chat__panel--${vm.$open.compute(o => o ? 'open' : 'closed')}">
+      <div
+        class="chat__panel chat__panel--${vm.$open.compute(o =>
+          o ? "open" : "closed"
+        )}"
+      >
         ${vm.$messages.compute(msgs => msgs.map(m => html`<p>${m}</p>`))}
       </div>
     </div>
   `,
-  onMount: (vm) => {
+  onMount: vm => {
     // Wire up external event sources
   },
-  onDestroy: (vm) => {
+  onDestroy: vm => {
     // Clean up subscriptions, timers, etc.
   },
 });
@@ -140,15 +144,15 @@ widget.mount();
 Creates a reactive DOM view from a template literal. Use `$`-prefixed properties for reactive bindings.
 
 ```typescript
-function html(strings: TemplateStringsArray, ...args: unknown[]): View
+function html(strings: TemplateStringsArray, ...args: unknown[]): View;
 ```
 
 **Returns:** A `View` (enhanced DocumentFragment) with `collect`, `mount`, and `unmount` methods.
 
 ```typescript
-import { html, useViewModel } from 'marjoram';
+import { html, useViewModel } from "marjoram";
 
-const vm = useViewModel({ name: 'World' });
+const vm = useViewModel({ name: "World" });
 const view = html`
   <div>
     <h1>Hello, ${vm.$name}!</h1>
@@ -157,9 +161,11 @@ const view = html`
 `;
 
 const { rename } = view.collect();
-rename.addEventListener('click', () => { vm.name = 'Marjoram'; });
+rename.addEventListener("click", () => {
+  vm.name = "Marjoram";
+});
 
-view.mount('#app');
+view.mount("#app");
 // view.unmount(); // removes from DOM + disposes observers
 ```
 
@@ -176,18 +182,20 @@ const view = html`
 `;
 
 const { saveBtn, cancelBtn } = view.collect();
-saveBtn.addEventListener('click', () => console.log('Saving...'));
+saveBtn.addEventListener("click", () => console.log("Saving..."));
 ```
 
 When using `createWidget`, refs are passed to `onMount` automatically:
 
 ```typescript
 createWidget({
-  target: '#app',
+  target: "#app",
   model: {},
-  render: (vm) => html`<button ref="action">Go</button>`,
+  render: vm => html`<button ref="action">Go</button>`,
   onMount: (vm, refs) => {
-    refs.action.addEventListener('click', () => { /* ... */ });
+    refs.action.addEventListener("click", () => {
+      /* ... */
+    });
   },
 });
 ```
@@ -197,10 +205,11 @@ createWidget({
 Creates a reactive view model for use outside of `createWidget`. Prefer `createWidget` for widgets.
 
 ```typescript
-function useViewModel<T extends Model>(model: T): ViewModel<T>
+function useViewModel<T extends Model>(model: T): ViewModel<T>;
 ```
 
 **Parameters:**
+
 - `model` - Initial data object to make reactive
 
 **Returns:** A proxied object that tracks changes and updates views automatically.
@@ -208,24 +217,26 @@ function useViewModel<T extends Model>(model: T): ViewModel<T>
 #### Basic Usage
 
 ```typescript
-import { html, useViewModel } from 'marjoram';
+import { html, useViewModel } from "marjoram";
 
 const viewModel = useViewModel({
-  name: 'John',
+  name: "John",
   age: 30,
-  active: true
+  active: true,
 });
 
 const view = html`
   <div>
     <h2>${viewModel.$name}</h2>
     <p>Age: ${viewModel.$age}</p>
-    <p>Status: ${viewModel.$active.compute(v => v ? 'Active' : 'Inactive')}</p>
+    <p>
+      Status: ${viewModel.$active.compute(v => (v ? "Active" : "Inactive"))}
+    </p>
   </div>
 `;
 
 // Updates automatically trigger DOM changes
-viewModel.name = 'Jane';
+viewModel.name = "Jane";
 viewModel.age = 25;
 ```
 
@@ -235,17 +246,17 @@ Define computed properties as functions in your model - they recalculate wheneve
 
 ```typescript
 const viewModel = useViewModel({
-  firstName: 'John',
-  lastName: 'Doe',
+  firstName: "John",
+  lastName: "Doe",
   // Computed property - takes the viewModel as parameter
-  fullName: (vm) => `${vm.firstName} ${vm.lastName}`,
-  
+  fullName: vm => `${vm.firstName} ${vm.lastName}`,
+
   price: 100,
   quantity: 2,
   // Computed properties can depend on other computed properties
-  subtotal: (vm) => vm.price * vm.quantity,
-  tax: (vm) => vm.subtotal * 0.1,
-  total: (vm) => vm.subtotal + vm.tax
+  subtotal: vm => vm.price * vm.quantity,
+  tax: vm => vm.subtotal * 0.1,
+  total: vm => vm.subtotal + vm.tax,
 });
 
 const view = html`
@@ -256,11 +267,12 @@ const view = html`
 `;
 
 // Update any property - all computed properties recalculate
-viewModel.firstName = 'Jane';  // fullName becomes "Jane Doe"
-viewModel.price = 150;         // all computed properties recalculate
+viewModel.firstName = "Jane"; // fullName becomes "Jane Doe"
+viewModel.price = 150; // all computed properties recalculate
 ```
 
 **Key Features:**
+
 - ✅ **Fine-grained tracking**: Computed properties only recalculate when their actual dependencies change — backed by a signal graph, not brute-force invalidation
 - ✅ **Read-only**: Attempting to set a computed property throws an error
 - ✅ **Chain-able**: Computed properties can depend on other computed properties
@@ -272,7 +284,7 @@ viewModel.price = 150;         // all computed properties recalculate
 ```typescript
 const viewModel = useViewModel({
   count: 5,
-  doubled: (vm) => vm.count * 2
+  doubled: vm => vm.count * 2,
 });
 
 // ❌ This throws an error
@@ -290,7 +302,7 @@ When using reactive properties in templates, prefix them with `$`:
 - `viewModel.$name` - Gets the reactive property for template binding
 
 ```typescript
-const viewModel = useViewModel({ message: 'Hello' });
+const viewModel = useViewModel({ message: "Hello" });
 
 // ✅ Correct - use $ prefix in templates
 const view = html`<p>${viewModel.$message}</p>`;
@@ -299,7 +311,7 @@ const view = html`<p>${viewModel.$message}</p>`;
 const view = html`<p>${viewModel.message}</p>`;
 
 // ✅ Correct - no $ prefix for getting/setting values
-viewModel.message = 'Updated!'; // DOM updates automatically
+viewModel.message = "Updated!"; // DOM updates automatically
 ```
 
 ### `repeat` — Keyed List Reconciliation
@@ -311,21 +323,22 @@ function repeat<T>(
   items: ReactiveArrayProp<T> | T[],
   keyFn: (item: T, index: number) => unknown,
   templateFn: (item: T, index: number) => Node
-): Node
+): Node;
 ```
 
 **Parameters:**
+
 - `items` — a reactive array prop (e.g. `vm.$todos`) or a static array.
 - `keyFn` — extracts a stable, unique key for each item. Typically an `id`. Using the array index as the key defeats reconciliation and should be avoided when items can be added, removed, or reordered.
 - `templateFn` — returns a DOM node for each item, typically via `` html`...` ``.
 
 ```typescript
-import { html, useViewModel, repeat } from 'marjoram';
+import { html, useViewModel, repeat } from "marjoram";
 
 const vm = useViewModel({
   todos: [
-    { id: 1, text: 'Buy milk', done: false },
-    { id: 2, text: 'Walk the dog', done: true },
+    { id: 1, text: "Buy milk", done: false },
+    { id: 2, text: "Walk the dog", done: true },
   ],
 });
 
@@ -334,22 +347,22 @@ const view = html`
     ${repeat(
       vm.$todos,
       todo => todo.id,
-      todo => html`<li class="${todo.done ? 'done' : ''}">${todo.text}</li>`
+      todo => html`<li class="${todo.done ? "done" : ""}">${todo.text}</li>`
     )}
   </ul>
 `;
 
-view.mount('#app');
+view.mount("#app");
 
 // Granular updates — only the added <li> is created; existing nodes are reused.
-vm.todos = [...vm.todos, { id: 3, text: 'Write docs', done: false }];
+vm.todos = [...vm.todos, { id: 3, text: "Write docs", done: false }];
 ```
 
 **When to use which:**
 
-| Use | For |
-|---|---|
-| `repeat(vm.$items, keyFn, tplFn)` | Lists that change over time — reorders, additions, removals, in-place edits |
+| Use                                            | For                                                                              |
+| ---------------------------------------------- | -------------------------------------------------------------------------------- |
+| `repeat(vm.$items, keyFn, tplFn)`              | Lists that change over time — reorders, additions, removals, in-place edits      |
 | `vm.$items.compute(items => items.map(tplFn))` | Static lists, or lists where re-rendering every item on any change is acceptable |
 
 ### Computed Properties
@@ -362,13 +375,13 @@ Define computed properties as functions in your model for multi-property depende
 
 ```typescript
 const viewModel = useViewModel({
-  firstName: 'John',
-  lastName: 'Doe',
-  email: 'john@example.com',
-  
+  firstName: "John",
+  lastName: "Doe",
+  email: "john@example.com",
+
   // Computed property with access to entire viewModel
-  fullName: (vm) => `${vm.firstName} ${vm.lastName}`,
-  displayText: (vm) => `${vm.fullName} (${vm.email})`
+  fullName: vm => `${vm.firstName} ${vm.lastName}`,
+  displayText: vm => `${vm.fullName} (${vm.email})`,
 });
 
 // Use in templates
@@ -378,11 +391,12 @@ const view = html`<div>${viewModel.$fullName}</div>`;
 console.log(viewModel.fullName); // "John Doe"
 
 // Recalculates when any property changes
-viewModel.firstName = 'Jane';
+viewModel.firstName = "Jane";
 console.log(viewModel.fullName); // "Jane Doe"
 ```
 
 **When to use:**
+
 - ✅ Deriving values from **multiple** properties
 - ✅ Complex calculations that need the entire viewModel context
 - ✅ Reusable computed values accessed in multiple places
@@ -394,56 +408,63 @@ console.log(viewModel.fullName); // "Jane Doe"
 Chain `.compute()` for simple transformations of a single property:
 
 ```typescript
-const viewModel = useViewModel({ 
-  firstName: 'John', 
+const viewModel = useViewModel({
+  firstName: "John",
   active: true,
-  items: ['a', 'b', 'c']
+  items: ["a", "b", "c"],
 });
 
 const view = html`
   <div>
     <!-- Simple single-property transformation -->
     <h1>${viewModel.$firstName.compute(name => name.toUpperCase())}</h1>
-    
+
     <!-- Conditional rendering -->
-    <span>${viewModel.$active.compute(v => v ? 'Active' : 'Inactive')}</span>
-    
+    <span>${viewModel.$active.compute(v => (v ? "Active" : "Inactive"))}</span>
+
     <!-- Array rendering -->
     <ul>
-      ${viewModel.$items.compute(items => items.map(item => html`<li>${item}</li>`))}
+      ${viewModel.$items.compute(items =>
+        items.map(item => html`<li>${item}</li>`)
+      )}
     </ul>
   </div>
 `;
 ```
 
 **When to use:**
+
 - ✅ Transforming a **single** property value
 - ✅ Template-specific formatting (e.g., uppercase, date formatting)
 - ✅ View-specific logic that doesn't belong in the model
 
 #### Comparison
 
-| Feature | Model-Level | View-Time `.compute()` |
-|---------|------------|------------------------|
-| **Define** | In viewModel | In template |
-| **Recalculation** | When dependencies change | Only when its property changes |
-| **Can access** | All viewModel properties | Single property value |
-| **Reusability** | High (use anywhere) | Low (template-specific) |
-| **Access** | `vm.propName` or `vm.$propName` | Only in templates via `vm.$prop` |
-| **Read-only** | Yes (throws on set) | N/A (not settable) |
-| **Performance** | Fine-grained (signal-tracked) | Fine-grained (single prop) |
-| **Best for** | Multi-property derived state | Single-property transforms |
+| Feature           | Model-Level                     | View-Time `.compute()`           |
+| ----------------- | ------------------------------- | -------------------------------- |
+| **Define**        | In viewModel                    | In template                      |
+| **Recalculation** | When dependencies change        | Only when its property changes   |
+| **Can access**    | All viewModel properties        | Single property value            |
+| **Reusability**   | High (use anywhere)             | Low (template-specific)          |
+| **Access**        | `vm.propName` or `vm.$propName` | Only in templates via `vm.$prop` |
+| **Read-only**     | Yes (throws on set)             | N/A (not settable)               |
+| **Performance**   | Fine-grained (signal-tracked)   | Fine-grained (single prop)       |
+| **Best for**      | Multi-property derived state    | Single-property transforms       |
 
 **Example combining both:**
 
 ```typescript
 const viewModel = useViewModel({
-  items: [{price: 10, qty: 2}, {price: 20, qty: 1}],
+  items: [
+    { price: 10, qty: 2 },
+    { price: 20, qty: 1 },
+  ],
   taxRate: 0.1,
-  
+
   // Model-level: calculate subtotal from multiple items
-  subtotal: (vm) => vm.items.reduce((sum, item) => sum + (item.price * item.qty), 0),
-  total: (vm) => vm.subtotal * (1 + vm.taxRate)
+  subtotal: vm =>
+    vm.items.reduce((sum, item) => sum + item.price * item.qty, 0),
+  total: vm => vm.subtotal * (1 + vm.taxRate),
 });
 
 const view = html`
@@ -455,13 +476,98 @@ const view = html`
 `;
 ```
 
+### `store` — Deep Reactive State
+
+`store()` is a peer to `signal()` for **deeply nested, mutable** state. Where `signal()` is shallow and reference-based, `store()` lets you mutate nested paths directly — `state.user.address.city = "x"` — and only the subscribers to that exact path re-run. No spread/replace ceremony, no whole-object invalidation.
+
+```typescript
+import { store, effect } from "marjoram";
+
+const state = store({
+  user: { name: "Alice", age: 30 },
+  todos: [{ id: 1, text: "Buy milk", done: false }],
+});
+
+effect(() => console.log(state.user.name)); // logs "Alice"
+
+state.user.age = 31; // ← effect does NOT re-run (different path)
+state.user.name = "Bob"; // ← effect re-runs, logs "Bob"
+state.todos.push({ id: 2, text: "Walk dog", done: false }); // granular array update
+```
+
+**`signal()` vs `store()` — pick at the import site:**
+
+| Use         | For                                                                       |
+| ----------- | ------------------------------------------------------------------------- |
+| `signal(x)` | Primitives, atoms, or whole objects swapped wholesale (`s.set(newValue)`) |
+| `store(x)`  | Plain objects/arrays you mutate in place (`obj.a.b = c`)                  |
+
+#### In view models and templates
+
+`useViewModel` accepts stores. Inside templates, `vm.$store.path.to.leaf` is a reactive binding to that specific path:
+
+```typescript
+const vm = useViewModel({
+  form: store({ user: { name: "", email: "" } }),
+});
+
+const view = html`
+  <input
+    value="${vm.$form.user.name}"
+    oninput="${e => (vm.form.user.name = e.target.value)}"
+  />
+  <p>Hello, ${vm.$form.user.name}!</p>
+`;
+```
+
+Typing in the input mutates `vm.form.user.name` directly; only the bindings to that path update.
+
+#### With `repeat()`
+
+Store arrays drive `repeat()` reactively — `push`/`pop`/`splice`/`sort` reconcile the keyed list:
+
+```typescript
+const vm = useViewModel({ todos: store([{ id: 1, text: "Buy milk" }]) });
+
+html`<ul>
+  ${repeat(
+    vm.$todos,
+    t => t.id,
+    t => html`<li>${t.text}</li>`
+  )}
+</ul>`;
+
+vm.todos.push({ id: 2, text: "Walk dog" }); // only the new <li> is created
+```
+
+#### Inspect & escape hatches
+
+```typescript
+import { store, snapshot, subscribe, isStore, markRaw, unwrap } from "marjoram";
+
+const s = store({ count: 0 });
+
+snapshot(s); // deep plain-object copy (safe to JSON.stringify)
+const off = subscribe(s, "count", (next, prev) => {
+  /* typed: numbers */
+});
+isStore(s); // true
+markRaw(bigBlob); // opt a value out of being proxied
+unwrap(s); // the raw backing object (mutations bypass reactivity)
+```
+
+#### What gets proxied
+
+Only **plain objects and arrays**. `Date`, `Map`, `Set`, `RegExp`, class instances, DOM nodes, frozen/sealed objects, and `markRaw`'d values pass through by reference, untouched. Stores are XSS-safe (values reach the DOM only through the escaping `html` template) and prototype-pollution-hardened (`__proto__`/`constructor`/`prototype` are not writable through a store). Full contract: [docs/STORES.md](docs/STORES.md).
+
 ---
+
 ## Examples
 
 ### Todo List Application
 
 ```typescript
-import { html, useViewModel } from 'marjoram';
+import { html, useViewModel } from "marjoram";
 
 interface Todo {
   id: number;
@@ -472,29 +578,32 @@ interface Todo {
 const TodoApp = () => {
   const viewModel = useViewModel({
     todos: [] satisfies Todo[],
-    newTodo: '',
-    filter: 'all' satisfies 'all' | 'active' | 'completed',
-    
+    newTodo: "",
+    filter: "all" satisfies "all" | "active" | "completed",
+
     // Computed properties for derived state
-    filteredTodos: (vm) => {
+    filteredTodos: vm => {
       switch (vm.filter) {
-        case 'active': return vm.todos.filter(t => !t.completed);
-        case 'completed': return vm.todos.filter(t => t.completed);
-        default: return vm.todos;
+        case "active":
+          return vm.todos.filter(t => !t.completed);
+        case "completed":
+          return vm.todos.filter(t => t.completed);
+        default:
+          return vm.todos;
       }
     },
-    
-    activeCount: (vm) => vm.todos.filter(t => !t.completed).length,
-    completedCount: (vm) => vm.todos.filter(t => t.completed).length
+
+    activeCount: vm => vm.todos.filter(t => !t.completed).length,
+    completedCount: vm => vm.todos.filter(t => t.completed).length,
   });
 
   const view = html`
     <div class="todo-app">
       <h1>Todo List</h1>
-      
+
       <div class="input-section">
-        <input 
-          ref="newTodoInput" 
+        <input
+          ref="newTodoInput"
           placeholder="What needs to be done?"
           value="${viewModel.$newTodo}"
         />
@@ -507,45 +616,77 @@ const TodoApp = () => {
       </div>
 
       <div class="filters">
-        <button ref="allFilter" class="${viewModel.$filter.compute(f => f === 'all' ? 'active' : '')}">All</button>
-        <button ref="activeFilter" class="${viewModel.$filter.compute(f => f === 'active' ? 'active' : '')}">Active</button>
-        <button ref="completedFilter" class="${viewModel.$filter.compute(f => f === 'completed' ? 'active' : '')}">Completed</button>
+        <button
+          ref="allFilter"
+          class="${viewModel.$filter.compute(f =>
+            f === "all" ? "active" : ""
+          )}"
+        >
+          All
+        </button>
+        <button
+          ref="activeFilter"
+          class="${viewModel.$filter.compute(f =>
+            f === "active" ? "active" : ""
+          )}"
+        >
+          Active
+        </button>
+        <button
+          ref="completedFilter"
+          class="${viewModel.$filter.compute(f =>
+            f === "completed" ? "active" : ""
+          )}"
+        >
+          Completed
+        </button>
       </div>
 
       <ul class="todo-list">
-        ${viewModel.$filteredTodos.compute(todos => todos.map(todo => html`
-          <li class="${todo.completed ? 'completed' : ''}">
-            <input 
-              type="checkbox" 
-              ${todo.completed ? 'checked' : ''}
-              data-id="${todo.id}"
-            />
-            <span>${todo.text}</span>
-            <button class="delete" data-id="${todo.id}">×</button>
-          </li>
-        `))}
+        ${viewModel.$filteredTodos.compute(todos =>
+          todos.map(
+            todo => html`
+              <li class="${todo.completed ? "completed" : ""}">
+                <input
+                  type="checkbox"
+                  ${todo.completed ? "checked" : ""}
+                  data-id="${todo.id}"
+                />
+                <span>${todo.text}</span>
+                <button class="delete" data-id="${todo.id}">×</button>
+              </li>
+            `
+          )
+        )}
       </ul>
     </div>
   `;
 
   // Event handlers
-  const { newTodoInput, addBtn, allFilter, activeFilter, completedFilter } = view.collect();
+  const { newTodoInput, addBtn, allFilter, activeFilter, completedFilter } =
+    view.collect();
 
-  addBtn.addEventListener('click', () => {
+  addBtn.addEventListener("click", () => {
     if (viewModel.newTodo.trim()) {
-      viewModel.todos = [...viewModel.todos, {
-        id: Date.now(),
-        text: viewModel.newTodo.trim(),
-        completed: false
-      }];
-      viewModel.newTodo = '';
-      newTodoInput.value = '';
+      viewModel.todos = [
+        ...viewModel.todos,
+        {
+          id: Date.now(),
+          text: viewModel.newTodo.trim(),
+          completed: false,
+        },
+      ];
+      viewModel.newTodo = "";
+      newTodoInput.value = "";
     }
   });
 
-  allFilter.addEventListener('click', () => viewModel.filter = 'all');
-  activeFilter.addEventListener('click', () => viewModel.filter = 'active');
-  completedFilter.addEventListener('click', () => viewModel.filter = 'completed');
+  allFilter.addEventListener("click", () => (viewModel.filter = "all"));
+  activeFilter.addEventListener("click", () => (viewModel.filter = "active"));
+  completedFilter.addEventListener(
+    "click",
+    () => (viewModel.filter = "completed")
+  );
 
   return view;
 };
@@ -556,16 +697,20 @@ document.body.appendChild(TodoApp());
 ### Counter with Animation
 
 ```typescript
-import { html, useViewModel } from 'marjoram';
+import { html, useViewModel } from "marjoram";
 
 const AnimatedCounter = () => {
   const viewModel = useViewModel({
     count: 0,
-    isAnimating: false
+    isAnimating: false,
   });
 
   const view = html`
-    <div class="counter ${viewModel.$isAnimating.compute(v => v ? 'animating' : '')}">
+    <div
+      class="counter ${viewModel.$isAnimating.compute(v =>
+        v ? "animating" : ""
+      )}"
+    >
       <h2>Count: ${viewModel.$count}</h2>
       <div class="controls">
         <button ref="decrement">-</button>
@@ -585,16 +730,16 @@ const AnimatedCounter = () => {
     }, 300);
   };
 
-  increment.addEventListener('click', () => {
+  increment.addEventListener("click", () => {
     animateChange(() => viewModel.count++);
   });
 
-  decrement.addEventListener('click', () => {
+  decrement.addEventListener("click", () => {
     animateChange(() => viewModel.count--);
   });
 
-  reset.addEventListener('click', () => {
-    animateChange(() => viewModel.count = 0);
+  reset.addEventListener("click", () => {
+    animateChange(() => (viewModel.count = 0));
   });
 
   return view;
@@ -604,7 +749,7 @@ const AnimatedCounter = () => {
 ### Data Fetching with Loading States
 
 ```typescript
-import { html, useViewModel } from 'marjoram';
+import { html, useViewModel } from "marjoram";
 
 interface User {
   id: number;
@@ -616,19 +761,21 @@ const UserList = () => {
   const viewModel = useViewModel({
     users: [] satisfies User[],
     loading: false,
-    error: null satisfies string | null
+    error: null satisfies string | null,
   });
 
   const loadUsers = async () => {
     viewModel.loading = true;
     viewModel.error = null;
-    
+
     try {
-      const response = await fetch('https://jsonplaceholder.typicode.com/users');
+      const response = await fetch(
+        "https://jsonplaceholder.typicode.com/users"
+      );
       const users = await response.json();
       viewModel.users = users;
     } catch (err) {
-      viewModel.error = 'Failed to load users';
+      viewModel.error = "Failed to load users";
     } finally {
       viewModel.loading = false;
     }
@@ -638,24 +785,30 @@ const UserList = () => {
     <div class="user-list">
       <h2>Users</h2>
       <button ref="loadBtn">Load Users</button>
-      
-      ${viewModel.$loading.compute(v => v ? html`<p>Loading...</p>` : '')}
-      ${viewModel.$error.compute(v => v ? html`<p class="error">${v}</p>` : '')}
-      
+
+      ${viewModel.$loading.compute(v => (v ? html`<p>Loading...</p>` : ""))}
+      ${viewModel.$error.compute(v =>
+        v ? html`<p class="error">${v}</p>` : ""
+      )}
+
       <ul>
-        ${viewModel.$users.compute(users => users.map(user => html`
-          <li>
-            <strong>${user.name}</strong>
-            <br>
-            <small>${user.email}</small>
-          </li>
-        `))}
+        ${viewModel.$users.compute(users =>
+          users.map(
+            user => html`
+              <li>
+                <strong>${user.name}</strong>
+                <br />
+                <small>${user.email}</small>
+              </li>
+            `
+          )
+        )}
       </ul>
     </div>
   `;
 
   const { loadBtn } = view.collect();
-  loadBtn.addEventListener('click', loadUsers);
+  loadBtn.addEventListener("click", loadUsers);
 
   return view;
 };
@@ -664,93 +817,93 @@ const UserList = () => {
 ### Form Validation
 
 ```typescript
-import { html, useViewModel } from 'marjoram';
+import { html, useViewModel } from "marjoram";
 
 const ContactForm = () => {
   const viewModel = useViewModel({
-    name: '',
-    email: '',
-    message: '',
+    name: "",
+    email: "",
+    message: "",
     submitted: false,
-    
+
     // Computed validation properties
-    nameError: (vm) => !vm.name.trim() ? 'Name is required' : '',
-    emailError: (vm) => {
-      if (!vm.email.trim()) return 'Email is required';
-      if (!/\S+@\S+\.\S+/.test(vm.email)) return 'Email is invalid';
-      return '';
+    nameError: vm => (!vm.name.trim() ? "Name is required" : ""),
+    emailError: vm => {
+      if (!vm.email.trim()) return "Email is required";
+      if (!/\S+@\S+\.\S+/.test(vm.email)) return "Email is invalid";
+      return "";
     },
-    messageError: (vm) => !vm.message.trim() ? 'Message is required' : '',
-    
-    isValid: (vm) => !vm.nameError && !vm.emailError && !vm.messageError
+    messageError: vm => (!vm.message.trim() ? "Message is required" : ""),
+
+    isValid: vm => !vm.nameError && !vm.emailError && !vm.messageError,
   });
 
   const view = html`
     <form class="contact-form" ref="form">
       <h2>Contact Us</h2>
-      
+
       <div class="field">
         <label>Name:</label>
         <input ref="nameInput" type="text" value="${viewModel.$name}" />
-        ${viewModel.$nameError.compute(err => 
-          err ? html`<span class="error">${err}</span>` : ''
+        ${viewModel.$nameError.compute(err =>
+          err ? html`<span class="error">${err}</span>` : ""
         )}
       </div>
-      
+
       <div class="field">
         <label>Email:</label>
         <input ref="emailInput" type="email" value="${viewModel.$email}" />
-        ${viewModel.$emailError.compute(err => 
-          err ? html`<span class="error">${err}</span>` : ''
+        ${viewModel.$emailError.compute(err =>
+          err ? html`<span class="error">${err}</span>` : ""
         )}
       </div>
-      
+
       <div class="field">
         <label>Message:</label>
         <textarea ref="messageInput">${viewModel.$message}</textarea>
-        ${viewModel.$messageError.compute(err => 
-          err ? html`<span class="error">${err}</span>` : ''
+        ${viewModel.$messageError.compute(err =>
+          err ? html`<span class="error">${err}</span>` : ""
         )}
       </div>
-      
-      <button 
-        type="submit" 
+
+      <button
+        type="submit"
         ref="submitBtn"
-        ${viewModel.$isValid.compute(valid => valid ? '' : 'disabled')}
+        ${viewModel.$isValid.compute(valid => (valid ? "" : "disabled"))}
       >
         Send Message
       </button>
-      
-      ${viewModel.$submitted.compute(v => v ? html`
-        <div class="success">Message sent successfully!</div>
-      ` : '')}
+
+      ${viewModel.$submitted.compute(v =>
+        v ? html` <div class="success">Message sent successfully!</div> ` : ""
+      )}
     </form>
   `;
 
   const { form, nameInput, emailInput, messageInput } = view.collect();
 
   // Sync inputs with view model
-  nameInput.addEventListener('input', (e) => {
+  nameInput.addEventListener("input", e => {
     viewModel.name = (e.target as HTMLInputElement).value;
   });
 
-  emailInput.addEventListener('input', (e) => {
+  emailInput.addEventListener("input", e => {
     viewModel.email = (e.target as HTMLInputElement).value;
   });
 
-  messageInput.addEventListener('input', (e) => {
+  messageInput.addEventListener("input", e => {
     viewModel.message = (e.target as HTMLTextAreaElement).value;
   });
 
-  form.addEventListener('submit', (e) => {
+  form.addEventListener("submit", e => {
     e.preventDefault();
     if (viewModel.isValid) {
       viewModel.submitted = true;
       // Reset form after 3 seconds
       setTimeout(() => {
-        viewModel.name = '';
-        viewModel.email = '';
-        viewModel.message = '';
+        viewModel.name = "";
+        viewModel.email = "";
+        viewModel.message = "";
         viewModel.submitted = false;
       }, 3000);
     }
@@ -761,12 +914,13 @@ const ContactForm = () => {
 ```
 
 ---
+
 ## TypeScript Support
 
 Marjoram is built with TypeScript and provides excellent type safety:
 
 ```typescript
-import { html, useViewModel, View, ViewModel } from 'marjoram';
+import { html, useViewModel, View, ViewModel } from "marjoram";
 
 // Type-safe view models
 interface AppState {
@@ -774,12 +928,12 @@ interface AppState {
     name: string;
     age: number;
   };
-  theme: 'light' | 'dark';
+  theme: "light" | "dark";
 }
 
 const viewModel: ViewModel<AppState> = useViewModel({
-  user: { name: 'John', age: 30 },
-  theme: 'light'
+  user: { name: "John", age: 30 },
+  theme: "light",
 });
 
 // Type-safe refs
@@ -801,13 +955,13 @@ Marjoram's reactivity is built on a **fine-grained signal graph**. Computed prop
 The signal primitives are available for direct use when you need reactive state outside of `createWidget`:
 
 ```typescript
-import { signal, computed, effect, batch } from 'marjoram';
+import { signal, computed, effect, batch } from "marjoram";
 
 // Writable reactive value
 const count = signal(0);
-count();       // read: 0 (tracks caller as subscriber)
-count.set(5);  // write: notifies dependents
-count.peek();  // read without tracking
+count(); // read: 0 (tracks caller as subscriber)
+count.set(5); // write: notifies dependents
+count.peek(); // read without tracking
 
 // Derived value — auto-tracks dependencies
 const doubled = computed(() => count() * 2);
@@ -836,14 +990,14 @@ dispose(); // stop the effect
 
 ```typescript
 const vm = useViewModel({
-  firstName: 'John',
-  lastName: 'Doe',
+  firstName: "John",
+  lastName: "Doe",
   age: 30,
-  fullName: (vm) => `${vm.firstName} ${vm.lastName}`,  // tracks firstName + lastName
-  isAdult: (vm) => vm.age >= 18,                         // tracks age only
+  fullName: vm => `${vm.firstName} ${vm.lastName}`, // tracks firstName + lastName
+  isAdult: vm => vm.age >= 18, // tracks age only
 });
 
-vm.age = 25;  // isAdult recomputes; fullName does NOT
+vm.age = 25; // isAdult recomputes; fullName does NOT
 ```
 
 ---
@@ -854,30 +1008,30 @@ Real numbers from the benchmark suite (`npm test -- --testPathPattern=benchmark`
 
 ### Widget Creation
 
-| Operation | Time | Per Widget |
-|-----------|------|------------|
-| Create + mount + destroy 1 widget | ~560μs | — |
-| Create + mount + destroy 100 widgets | ~9ms | ~93μs |
-| Create + mount + destroy 1000 widgets | ~297ms | ~297μs |
+| Operation                             | Time   | Per Widget |
+| ------------------------------------- | ------ | ---------- |
+| Create + mount + destroy 1 widget     | ~560μs | —          |
+| Create + mount + destroy 100 widgets  | ~9ms   | ~93μs      |
+| Create + mount + destroy 1000 widgets | ~297ms | ~297μs     |
 
 ### Update Throughput
 
-| Operation | Time | Throughput |
-|-----------|------|------------|
-| 10,000 sequential property updates | ~3.5ms | ~2,800 ops/ms |
+| Operation                              | Time   | Throughput    |
+| -------------------------------------- | ------ | ------------- |
+| 10,000 sequential property updates     | ~3.5ms | ~2,800 ops/ms |
 | 5,000 multi-property updates (5 props) | ~1.8ms | ~2,800 ops/ms |
-| 1,000 computed chain updates (3-deep) | ~820μs | — |
-| 1,000 array pushes | ~32ms | — |
+| 1,000 computed chain updates (3-deep)  | ~820μs | —             |
+| 1,000 array pushes                     | ~32ms  | —             |
 
 ### Signal Primitives
 
-| Operation | Time | Throughput |
-|-----------|------|------------|
-| 100k raw signal writes | ~5.7ms | ~17,500 ops/ms |
-| 10k signal→computed updates | ~580μs | ~17,100 ops/ms |
+| Operation                         | Time       | Throughput       |
+| --------------------------------- | ---------- | ---------------- |
+| 100k raw signal writes            | ~5.7ms     | ~17,500 ops/ms   |
+| 10k signal→computed updates       | ~580μs     | ~17,100 ops/ms   |
 | Diamond dependency (1000 updates) | 1000 evals | Zero wasted work |
 
-*Measured in jsdom (Jest). Browser performance will differ — run `npm test -- --testPathPattern=benchmark` for your environment.*
+_Measured in jsdom (Jest). Browser performance will differ — run `npm test -- --testPathPattern=benchmark` for your environment._
 
 ### Why it's fast
 
@@ -907,13 +1061,13 @@ While Marjoram provides powerful reactive capabilities, there are some architect
 const viewModel = useViewModel({
   count: 5,
   // ✅ This is a computed property (takes viewModel as parameter)
-  doubled: (vm) => vm.count * 2
+  doubled: vm => vm.count * 2,
 });
 
 // ❌ You cannot store regular functions in viewModels
 const viewModel = useViewModel({
   count: 5,
-  increment: () => count++ // This will be treated as a computed property
+  increment: () => count++, // This will be treated as a computed property
 });
 ```
 
@@ -928,68 +1082,51 @@ const decrement = () => viewModel.count--;
 
 const view = html`<button ref="btn">Count: ${viewModel.$count}</button>`;
 const { btn } = view.collect();
-btn.addEventListener('click', increment);
+btn.addEventListener("click", increment);
 ```
 
-### Deep Nested Property Reactivity
+### Deep Nested Property Reactivity — use `store()`
 
-Deep nested property updates don't automatically trigger reactive updates:
+Plain `useViewModel` values are shallow: deep nested mutations don't trigger updates. **This is what [`store()`](#store--deep-reactive-state) is for.**
 
 ```typescript
-const viewModel = useViewModel({
-  user: {
-    profile: {
-      name: "John"
-    }
-  }
-});
+// ❌ Shallow value — deep mutation does nothing
+const vm = useViewModel({ user: { profile: { name: "John" } } });
+vm.user.profile.name = "Jane"; // no update
 
-const view = html`<div>${viewModel.user.profile.name}</div>`;
-
-// ❌ This won't trigger a DOM update
-viewModel.user.profile.name = "Jane";
-
-// ✅ Workaround: Reassign the parent object
-viewModel.user = { 
-  ...viewModel.user, 
-  profile: { ...viewModel.user.profile, name: "Jane" } 
-};
+// ✅ store() — deep mutation is granularly reactive
+const vm2 = useViewModel({ user: store({ profile: { name: "John" } }) });
+vm2.user.profile.name = "Jane"; // updates only bindings to that path
 ```
 
-### Array Mutation Reactivity
+(Without `store()`, the shallow workaround is to reassign the parent: `vm.user = { ...vm.user, profile: { ...vm.user.profile, name: "Jane" } }`.)
 
-Direct array mutations (push, pop, splice, etc.) don't trigger reactive updates:
+### Array Mutation Reactivity — use `store()`
+
+Direct array mutations on a plain value don't trigger updates. **A `store()` array makes them reactive**, and pairs with `repeat()`:
 
 ```typescript
-const viewModel = useViewModel({ items: ['a', 'b', 'c'] });
-
-const view = html`
-  <ul>
-    ${viewModel.$items.compute(items => items.map(item => html`<li>${item}</li>`))}
-  </ul>
-`;
-
-// ❌ These won't trigger DOM updates
-viewModel.items.push('d');
-viewModel.items.pop();
-
-// ✅ Workaround: Reassign the entire array
-viewModel.items = [...viewModel.items, 'd'];
-viewModel.items = viewModel.items.slice(0, -1);
+// ✅ store() array — push/pop/splice reconcile reactively
+const vm = useViewModel({ items: store(["a", "b", "c"]) });
+html`<ul>
+  ${repeat(
+    vm.$items,
+    (_, i) => i,
+    item => html`<li>${item}</li>`
+  )}
+</ul>`;
+vm.items.push("d"); // the new <li> is created; existing nodes reused
 ```
 
-### Nested Object Property Addition
+(Without `store()`, reassign the whole array: `vm.items = [...vm.items, 'd']`.)
 
-Adding new properties to nested objects may not work as expected:
+### Nested Object Property Addition — use `store()`
+
+Adding new keys to a `store()`-wrapped object is reactive (iteration subscribers via `for...in`/`Object.keys` re-run):
 
 ```typescript
-const viewModel = useViewModel({ config: { theme: 'dark' } });
-
-// ❌ This might not work reliably
-viewModel.config.newProperty = 'value';
-
-// ✅ Better: Add properties at the top level
-viewModel.newProperty = 'value';
+const vm = useViewModel({ config: store({ theme: "dark" }) });
+vm.config.newProperty = "value"; // reactive: a new key was added
 ```
 
 ### TypeScript Array Method Support
@@ -1015,7 +1152,7 @@ const total = viewModel.$items.reduce((sum, x) => sum + x, 0);
 - **Computed properties** use fine-grained signal tracking — they only recompute when their actual dependencies change
 - **DOM updates** are batched via microtask queue. Multiple property writes in the same tick produce a single DOM update
 - **Memory**: `widget.destroy()` and `view.unmount()` dispose all signals and observers. Long-lived apps should call these on removal
-- **Large Object Updates**: Deep nested object updates require parent reassignment (see Limitations)
+- **Deep nested state**: use [`store()`](#store--deep-reactive-state) for granular nested reactivity (plain `useViewModel` values are shallow)
 
 **Note on Testing:** When writing tests with computed properties, flush the microtask queue twice:
 
@@ -1027,7 +1164,7 @@ await flushMicrotasks(); // Flush computed property DOM update
 
 ### Planned Improvements
 
-- **Deep reactivity for nested objects** - Automatic detection of nested property changes
+- ✅ **Deep reactivity for nested objects** — shipped in v1.1.0 as [`store()`](#store--deep-reactive-state)
 - **Framework adapters** - First-class `<marjoram-widget>` custom element wrappers for React/Vue/Angular host pages
 - **Widget distribution tooling** - Config schemas, sandbox policies, inter-widget communication
 

--- a/demo/store-example/index.html
+++ b/demo/store-example/index.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Marjoram — store() deep reactivity demo</title>
+    <style>
+      body {
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        max-width: 640px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        color: #1a1a1a;
+      }
+      h1 {
+        font-size: 1.3rem;
+      }
+      .panel {
+        border: 1px solid #e0e0e0;
+        border-radius: 8px;
+        padding: 1rem;
+        margin: 1rem 0;
+      }
+      label {
+        display: block;
+        margin: 0.5rem 0;
+      }
+      input {
+        padding: 0.35rem 0.5rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        width: 16rem;
+      }
+      .count {
+        color: #3ba776;
+        font-variant-numeric: tabular-nums;
+        font-size: 0.85rem;
+      }
+      .preview {
+        background: #f6f8fa;
+        padding: 0.5rem 0.75rem;
+        border-radius: 4px;
+        font-family: ui-monospace, monospace;
+        white-space: pre-wrap;
+      }
+      button {
+        padding: 0.35rem 0.75rem;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        cursor: pointer;
+      }
+      li.done {
+        text-decoration: line-through;
+        color: #999;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Marjoram <code>store()</code> — granular deep reactivity</h1>
+    <p>
+      Each field shows its own render count. Editing one deeply-nested field
+      re-renders <em>only that field's binding</em> — the counts prove it.
+    </p>
+
+    <div class="panel" id="form"></div>
+    <div class="panel" id="todos"></div>
+
+    <!-- Load the built UMD bundle (run `npm run build` first). -->
+    <script src="../../dist/marjoram.umd.js"></script>
+    <script>
+      const { createWidget, html, useViewModel, store, repeat, snapshot } =
+        window.marjoram;
+
+      // Per-binding render counters so granularity is visible.
+      const renders = { name: 0, email: 0, city: 0, zip: 0 };
+      const bump = k => {
+        renders[k]++;
+        return renders[k];
+      };
+
+      // --- Deeply nested form, all driven by ONE store ---
+      createWidget({
+        target: "#form",
+        model: {
+          form: store({
+            user: { name: "Alice", email: "alice@example.com" },
+            address: { city: "NYC", zip: "10001" },
+          }),
+        },
+        render: vm => html`
+          <h2>Nested form</h2>
+          <label
+            >Name
+            <input
+              value="${vm.$form.user.name}"
+              oninput="${e => (vm.form.user.name = e.target.value)}"
+          /></label>
+          <span class="count"
+            >name binding renders:
+            ${vm.$form.user.name.compute(() => bump("name"))}</span
+          >
+
+          <label
+            >Email
+            <input
+              value="${vm.$form.user.email}"
+              oninput="${e => (vm.form.user.email = e.target.value)}"
+          /></label>
+          <span class="count"
+            >email binding renders:
+            ${vm.$form.user.email.compute(() => bump("email"))}</span
+          >
+
+          <label
+            >City
+            <input
+              value="${vm.$form.address.city}"
+              oninput="${e => (vm.form.address.city = e.target.value)}"
+          /></label>
+          <span class="count"
+            >city binding renders:
+            ${vm.$form.address.city.compute(() => bump("city"))}</span
+          >
+
+          <label
+            >Zip
+            <input
+              value="${vm.$form.address.zip}"
+              oninput="${e => (vm.form.address.zip = e.target.value)}"
+          /></label>
+          <span class="count"
+            >zip binding renders:
+            ${vm.$form.address.zip.compute(() => bump("zip"))}</span
+          >
+
+          <p class="preview">
+            ${vm.$form.compute(f => JSON.stringify(snapshot(f), null, 2))}
+          </p>
+        `,
+      }).mount();
+
+      // --- Keyed todo list driven by a store array + repeat() ---
+      createWidget({
+        target: "#todos",
+        model: {
+          todos: store([
+            { id: 1, text: "Buy milk", done: false },
+            { id: 2, text: "Walk dog", done: false },
+          ]),
+          nextId: 3,
+        },
+        render: vm => html`
+          <h2>Keyed todos (store array + repeat)</h2>
+          <ul>
+            ${repeat(
+              vm.$todos,
+              t => t.id,
+              t => html`<li class="${t.done ? "done" : ""}">${t.text}</li>`
+            )}
+          </ul>
+          <button
+            onclick="${() =>
+              vm.todos.push({
+                id: vm.nextId++,
+                text: "New task " + (vm.nextId - 1),
+                done: false,
+              })}"
+          >
+            Add todo
+          </button>
+          <button onclick="${() => vm.todos.pop()}">Remove last</button>
+        `,
+      }).mount();
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marjoram",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Widget SDK toolkit — reactive state, template binding, and DOM isolation in under 5KB with zero dependencies",
   "keywords": [
     "dom",


### PR DESCRIPTION
## Summary

Final phase of the deep-reactivity initiative. Release prep for **v1.1.0** (additive, non-breaking). Documents `store()`, adds a demo, bumps the version. **Does not publish** — `npm run release` is a manual maintainer step.

## Changes

- **README**
  - New `### store — Deep Reactive State` API section: signal-vs-store decision table, basic usage, view-model + template path-binding, `repeat()` with store arrays, inspect/escape-hatch APIs, proxied-vs-passthrough boundary + security note.
  - Rewrote the three "Current Limitations" that `store()` resolves (deep nested reactivity, array mutation, nested key addition) to point at `store()` with before/after snippets.
  - Marked "deep reactivity" as shipped; added `store` to the TOC.
- **`demo/store-example/index.html`** — self-contained, build-step-free demonstrator (loads the UMD bundle). A deeply-nested form with per-field render counters that *prove* granular updates, plus a keyed todo list (store array + `repeat()`). Isolated from the e-commerce demo app.
- **`CHANGELOG.md`** — new; documents 1.1.0 (added APIs + security hardening) and a 1.0.0 baseline.
- **`package.json`** — `1.0.0` → `1.1.0`.

## Verification

- type-check clean, lint 0 errors (49 pre-existing warnings)
- **416/416** tests
- build clean, no circular deps, ESM ~5.9 KB gzipped
- verified the built CJS/UMD bundle exports every symbol the demo references
- ⚠️ **NOT browser-tested** — the demo HTML can't be exercised in this environment. Please open `demo/store-example/index.html` after `npm run build` to confirm live behavior before tagging.

## Release checklist (maintainer)

- [ ] Merge this PR
- [ ] `npm run build` + open `demo/store-example/index.html`, sanity-check the form granularity + todo reconciliation
- [ ] Tag `v1.1.0`
- [ ] `npm run release` (runs test + build + `npm publish --access=public`)
- [ ] Optionally publish a `v1.1.0-rc.0` via `npm publish --tag next` first for a dogfooding window (per the rollout cadence in STORE_IMPLEMENTATION_PLAN.md)

## The initiative, end to end

Phases 0–8 + the 7.5 review remediation: `store()` core → arrays → view integration → DX (snapshot/subscribe/devtools) → comprehensive tests → benchmarks → 3-agent independent review → security/correctness/coverage remediation → docs + release prep. **416 tests, ~5.9 KB gzipped, zero runtime deps.**