### PR TITLE
docs: polish store() docs — TOC, accuracy, navigability

### DIFF
--- a/docs/STORES.md
+++ b/docs/STORES.md
@@ -1,16 +1,34 @@
 # Stores — Deep Reactivity for Marjoram
 
-> **Status:** Implemented (Phases 0–7.5, merged to `main`). Tracks the work outlined in [STORE_IMPLEMENTATION_PLAN.md](STORE_IMPLEMENTATION_PLAN.md). This document is the public contract; the implementation has been reviewed against it and hardened (see the security and correctness passes in Phase 7.5).
->
-> **Audience:** Two readers. (1) End users deciding whether and how to use `store()`. (2) Contributors implementing or reviewing the work. Sections are flagged where one audience matters more than the other.
+> **Status:** Shipped in v1.1.0. This is the canonical contract for `store()`; the implementation is reviewed and hardened against it. For the "why" behind the design, see [STORE_RESEARCH_FINDINGS.md](STORE_RESEARCH_FINDINGS.md); for the build history, [STORE_IMPLEMENTATION_PLAN.md](STORE_IMPLEMENTATION_PLAN.md).
 
----
+**Quick links:** [API](#4-the-api-surface) · [signal vs store](#3-when-to-use-which) · [granularity](#5-granularity-guarantees) · [what's proxied](#6-boundary-rules--what-gets-proxied) · [templates / useViewModel / repeat](#10-integration-with-the-rest-of-marjoram) · [gotchas](#12-gotchas) · [examples](#14-worked-examples)
+
+## Contents
+
+1. [Overview](#1-overview)
+2. [Why a separate primitive](#2-why-a-separate-primitive)
+3. [When to use which (`signal` vs `store`)](#3-when-to-use-which)
+4. [The API surface](#4-the-api-surface) — `store` · `snapshot` · `subscribe` · `markRaw` · `isStore` / `unwrap`
+5. [Granularity guarantees](#5-granularity-guarantees)
+6. [Boundary rules — what gets proxied](#6-boundary-rules--what-gets-proxied)
+7. [Arrays](#7-arrays)
+8. [Type system](#8-type-system)
+9. [Lifecycle and cleanup](#9-lifecycle-and-cleanup)
+10. [Integration: templates, `useViewModel`, `repeat`, computed/effect](#10-integration-with-the-rest-of-marjoram)
+11. [Comparison to peers](#11-comparison-to-peers)
+12. [Gotchas](#12-gotchas)
+13. [What `store()` deliberately does not do](#13-what-store-deliberately-does-not-do)
+14. [Worked examples](#14-worked-examples)
+15. [Cross-references](#15-cross-references)
+
+> Most sections serve both end users and contributors. A handful of internal-mechanism notes are called out inline.
 
 ## 1. Overview
 
-`store()` is a new reactivity primitive being added as a **peer to `signal()`**. Where `signal()` is shallow and reference-based (good for primitives, atoms, references to whole objects), `store()` is **deep and path-granular**: you can mutate `state.user.address.city = "x"` and only the subscribers to `user.address.city` re-run. No spread/replace ceremony, no `.update(fn)` wrapper, no virtual DOM, no whole-object invalidation.
+`store()` is a reactivity primitive — a **peer to `signal()`**. Where `signal()` is shallow and reference-based (good for primitives, atoms, references to whole objects), `store()` is **deep and path-granular**: you can mutate `state.user.address.city = "x"` and only the subscribers to `user.address.city` re-run. No spread/replace ceremony, no `.update(fn)` wrapper, no virtual DOM, no whole-object invalidation.
 
-Both primitives remain valid. Pick at the import site:
+Both primitives are first-class. Pick at the import site:
 
 ```ts
 import { signal, store } from "marjoram";
@@ -22,9 +40,7 @@ count.set(5);
 state.user.name = "Bob"; // ← just works; subscribers to that path re-run
 ```
 
-This document is the contract `store()` will be held to.
-
-## 2. Why a separate primitive (not "deep by default")
+## 2. Why a separate primitive
 
 Marjoram's existing API is built on **explicitness at the call site**. The `$` prefix rule (`vm.$name` reactive, `vm.name` value) makes reactivity legible to anyone reading the code. A flag like `{ deep: true }` declared once and acting invisibly everywhere would break that contract — the most consequential reactivity (nested state) would become the _least_ visible.
 
@@ -35,7 +51,7 @@ Two named primitives keeps the principle intact:
 
 A reader can predict behavior from the import line alone.
 
-## 3. When to use which (audience: users)
+## 3. When to use which
 
 Choose based on the _shape_ of the state, not its size:
 
@@ -53,18 +69,15 @@ Choose based on the _shape_ of the state, not its size:
 - "I want to write `signal.set(newValue)`" → `signal()`.
 - "It's just a number" → `signal()`. (Wrapping a number in a `store` is technically allowed but pointless; the primitive itself isn't proxiable.)
 
-## 4. The API surface (audience: both)
+## 4. The API surface
 
 The whole public surface, deliberately small:
 
 ```ts
 // Core
-export function store<T extends object>(
-  initial: T,
-  options?: StoreOptions
-): Store<T>;
+export function store<T extends object>(initial: T): Store<T>;
 
-// Type
+// Type — structurally T, with a phantom brand for isStore() narrowing.
 export type Store<T extends object> = T & { readonly [__brand]: "Store" };
 
 // Inspect & escape hatches
@@ -93,15 +106,9 @@ export type PathValue<
   T,
   P extends string,
 > = /* resolves path to value type */ unknown;
-
-// Options
-export interface StoreOptions {
-  /** Optional name for devtools display and dev-mode warnings. */
-  name?: string;
-}
 ```
 
-### 4.1 `store(initial, options?)`
+### 4.1 `store(initial)`
 
 Wraps a plain object or array in a deeply reactive proxy. Returns a value that **is** structurally `T` (you can pass it anywhere `T` is expected) but is also reactive: reads inside a `computed`/`effect`/`html` template track the exact paths touched, and writes notify only subscribers to the affected paths.
 
@@ -181,7 +188,7 @@ if (isStore(value)) {
 }
 ```
 
-## 5. Granularity guarantees (audience: both)
+## 5. Granularity guarantees
 
 This is the load-bearing contract. Implementations and tests will assert it exactly.
 
@@ -250,7 +257,7 @@ batch(() => {
 }); // ← effects re-run once, not twice
 ```
 
-## 6. Boundary rules — what gets proxied (audience: both)
+## 6. Boundary rules — what gets proxied
 
 A store proxies **only plain objects and arrays**. Everything else is stored and returned by reference, unmodified. The boundary is checked once at proxy-creation time per nested value.
 
@@ -270,7 +277,7 @@ A store proxies **only plain objects and arrays**. Everything else is stored and
 
 **Consequence for users:** if you want reactive `Map` or `Set`, you store a plain object/array. Reactive `Map`/`Set` variants are explicitly out of scope for v1.1 (see §13).
 
-## 7. Arrays (audience: both)
+## 7. Arrays
 
 Arrays are first-class. Three subtleties to call out:
 
@@ -278,9 +285,9 @@ Arrays are first-class. Three subtleties to call out:
 2. **Mutating methods produce a single notification round.** `arr.push(a, b, c)` notifies subscribers to indices `length`, `length+1`, `length+2`, and `length` itself — but they fire in one batched round, so a single effect re-runs once, not four times. Same for `pop`, `shift`, `unshift`, `splice`, `sort`, `reverse`, `fill`, `copyWithin`.
 3. **Read methods work via the normal proxy `get` path.** `map`, `filter`, `forEach`, `find`, `reduce`, `slice`, `concat`, `join`, `includes`, `indexOf`, `some`, `every`, `findIndex` — no special-casing. They iterate, the proxy registers the dependency, done.
 
-`repeat()` (see [README.md](../README.md#repeat--keyed-list-reconciliation)) consumes store arrays directly. The integration is one of the deliverables in Phase 4.
+`repeat()` (see [README.md](../README.md#repeat--keyed-list-reconciliation)) consumes store arrays directly — see §10.3.
 
-## 8. Type system (audience: both)
+## 8. Type system
 
 `Store<T>` preserves `T` structurally through arbitrary depth. There is no `unknown`, no loss of generic parameters, no need for `as` casts.
 
@@ -314,7 +321,7 @@ The `Store<T>` brand is a phantom `unique symbol` property so that:
 
 But: at any read site, the brand is transparent — you write `state.user.name` not `state.user.name.value` or anything similar. **There is no `.value` ceremony.** This is the headline DX win over Vue's `ref`.
 
-## 9. Lifecycle and cleanup (audience: both)
+## 9. Lifecycle and cleanup
 
 ### 9.1 Ownership
 
@@ -335,7 +342,7 @@ This matters because long-lived stores with churning data (e.g., a list of 100k 
 
 `store()` does not return a `.dispose()` method. Disposal is implicit via the ownership chain: when the owning scope tears down, the store's subscribers are notified and the path tree is dropped. This matches `useViewModel`'s existing implicit-cleanup model. Users with exotic lifecycle needs can wrap a store in a custom scope.
 
-## 10. Integration with the rest of Marjoram (audience: both)
+## 10. Integration with the rest of Marjoram
 
 ### 10.1 `html` templates
 
@@ -405,23 +412,23 @@ Zero changes required. Stores expose their tracked paths as `SignalNode`s — th
 
 This is the central architectural win: there is no parallel reactivity system to maintain.
 
-## 11. Comparison to peers (audience: users + contributors)
+## 11. Comparison to peers
 
 Honest. Where competitors are better, we say so.
 
-| Feature                                     | Marjoram `store` (this proposal) | Solid `createStore` | Vue 3 `reactive`                    | Valtio `proxy`    | MobX `observable` |
-| ------------------------------------------- | -------------------------------- | ------------------- | ----------------------------------- | ----------------- | ----------------- |
-| Deep reactive                               | ✅                               | ✅                  | ✅                                  | ✅                | ✅                |
-| Path-level granularity                      | ✅                               | ✅                  | ✅                                  | ✅                | partial           |
-| Mutable-feeling API                         | ✅                               | ⚠️ explicit setter  | ✅                                  | ✅                | ✅                |
-| Plain object/array only (no class wrapping) | ✅                               | ✅                  | partial (uses `markRaw` to opt out) | ✅                | needs config      |
-| Atomic multi-path updates                   | via `batch()`                    | ✅ path-setter      | via `batch`                         | via `batch`       | via `action`      |
-| `Map`/`Set` reactive variants               | ❌ (deferred)                    | ❌                  | ✅                                  | ✅                | ✅                |
-| Snapshot to plain object                    | ✅ `snapshot()`                  | ✅ `unwrap`/manual  | ✅ `toRaw` (shallow)                | ✅ `snapshot`     | partial           |
-| Devtools custom formatter                   | ✅ (planned)                     | ❌                  | ✅                                  | ❌                | ✅                |
-| Type-preserving through depth               | ✅                               | ✅                  | ✅                                  | partial           | partial           |
-| Zero runtime dependencies                   | ✅                               | ✅                  | ❌                                  | ❌                | ❌                |
-| Library size (whole lib gzipped)            | ~5KB target                      | ~7KB                | ~34KB                               | ~3KB (just store) | ~16KB             |
+| Feature                                     | Marjoram `store` | Solid `createStore` | Vue 3 `reactive`                    | Valtio `proxy`    | MobX `observable` |
+| ------------------------------------------- | ---------------- | ------------------- | ----------------------------------- | ----------------- | ----------------- |
+| Deep reactive                               | ✅               | ✅                  | ✅                                  | ✅                | ✅                |
+| Path-level granularity                      | ✅               | ✅                  | ✅                                  | ✅                | partial           |
+| Mutable-feeling API                         | ✅               | ⚠️ explicit setter  | ✅                                  | ✅                | ✅                |
+| Plain object/array only (no class wrapping) | ✅               | ✅                  | partial (uses `markRaw` to opt out) | ✅                | needs config      |
+| Atomic multi-path updates                   | via `batch()`    | ✅ path-setter      | via `batch`                         | via `batch`       | via `action`      |
+| `Map`/`Set` reactive variants               | ❌ (deferred)    | ❌                  | ✅                                  | ✅                | ✅                |
+| Snapshot to plain object                    | ✅ `snapshot()`  | ✅ `unwrap`/manual  | ✅ `toRaw` (shallow)                | ✅ `snapshot`     | partial           |
+| Devtools custom formatter                   | ✅ (planned)     | ❌                  | ✅                                  | ❌                | ✅                |
+| Type-preserving through depth               | ✅               | ✅                  | ✅                                  | partial           | partial           |
+| Zero runtime dependencies                   | ✅               | ✅                  | ❌                                  | ❌                | ❌                |
+| Library size (whole lib gzipped)            | ~5KB target      | ~7KB                | ~34KB                               | ~3KB (just store) | ~16KB             |
 
 **Where competitors are honestly better:**
 
@@ -429,7 +436,7 @@ Honest. Where competitors are better, we say so.
 - **Vue's reactive `Map`/`Set`.** Deferred — adding them is a real cost in bundle size and complexity that we don't think pays rent for the typical embeddable-widget use case. Revisit in v1.3+ if demand is real.
 - **MobX's `action` boundaries** for clearer transactional semantics. Our answer is `batch()`, which is functionally equivalent but less semantically opinionated.
 
-## 12. Gotchas — document these up front (audience: users)
+## 12. Gotchas
 
 Failure modes we know exist and how to think about them.
 
@@ -474,9 +481,9 @@ raw.user.name = "Bob"; // ← no notification — you bypassed reactivity
 
 If you write through `unwrap`, you broke the contract on purpose. Re-read through the proxy after.
 
-## 13. What this design explicitly does NOT do (audience: both)
+## 13. What `store()` deliberately does not do
 
-Scope guard — features we considered and rejected (for v1.1):
+Scope guard — features considered and deliberately left out of v1.1:
 
 - **Reactive `Map`/`Set`.** Real complexity for narrow benefit in the embeddable-widget use case. Defer to v1.3 if demand is real.
 - **Time-travel / undo built-in.** `snapshot()` is the primitive; building undo on top is a 30-line userland helper.
@@ -486,22 +493,9 @@ Scope guard — features we considered and rejected (for v1.1):
 - **Cross-store derivations as a built-in primitive.** Already covered by `computed()` reading from multiple stores.
 - **Server/client serialization protocol.** `snapshot()` is the building block; SSR hydration is a downstream library, not a primitive concern.
 
-## 14. Open questions
+## 14. Worked examples
 
-All previously-open design questions have been resolved by the research pass documented in [STORE_RESEARCH_FINDINGS.md](STORE_RESEARCH_FINDINGS.md):
-
-| ID  | Question                                                 | Resolution                        | Reason                                                                                      |
-| --- | -------------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------- |
-| 1   | Auto-store nested plain objects in `useViewModel`?       | **No** — explicit `store()` only  | Non-breaking-change rule (see [STORE_IMPLEMENTATION_PLAN.md](STORE_IMPLEMENTATION_PLAN.md)) |
-| 2   | `produce`-style transactions?                            | **No** — `batch()` covers it      | Valtio ships without; structural-sharing cost not worth it                                  |
-| 3   | Method-vs-data collision policy on path-binding proxies? | **Method wins, dev-mode warning** | Matches Vue's `.value` precedent                                                            |
-| 4   | `subscribe()` accepts a path filter?                     | **Yes — compile-time-typed path** | See §4.3, §8                                                                                |
-
-Phase 2 implementation can proceed.
-
-## 15. Worked examples (audience: users)
-
-### 15.1 A nested form
+### 14.1 A nested form
 
 ```ts
 import { createWidget, html, useViewModel, store, when } from "marjoram";
@@ -550,7 +544,7 @@ createWidget<FormState>({
 
 The granularity guarantee: typing in the name field re-renders _only_ the name input's binding and the `isValid` computed (which the disabled state and `when` depend on). The email input is untouched.
 
-### 15.2 A keyed todo list
+### 14.2 A keyed todo list
 
 ```ts
 import { createWidget, html, useViewModel, store, repeat } from "marjoram";
@@ -601,10 +595,12 @@ vm.todos.find(t => t.id === 1).done = true;
 // Only that <li>'s checkbox attribute updates.
 ```
 
-## 16. Cross-references
+## 15. Cross-references
 
-- [STORE_IMPLEMENTATION_PLAN.md](STORE_IMPLEMENTATION_PLAN.md) — phased implementation roadmap, versioning, non-breaking-change rules.
-- [src/reactivity/signal.ts](../src/reactivity/signal.ts) — existing primitives stores will compose with.
-- [src/schema/schemaPropFactory.ts](../src/schema/schemaPropFactory.ts) — the `SchemaProp` shape that path-binding proxies will conform to.
-- [src/view/external/repeat.ts](../src/view/external/repeat.ts) — keyed list reconciler stores will integrate with.
-- [CLAUDE.md](../CLAUDE.md) §4, §5, §7 — the project conventions and anti-patterns this design respects.
+- [STORE_IMPLEMENTATION_PLAN.md](STORE_IMPLEMENTATION_PLAN.md) — the build history, versioning, and non-breaking-change rules (historical).
+- [STORE_RESEARCH_FINDINGS.md](STORE_RESEARCH_FINDINGS.md) — competitor-source review that shaped the design decisions (historical).
+- [src/reactivity/store.ts](../src/reactivity/store.ts) — the implementation.
+- [src/reactivity/signal.ts](../src/reactivity/signal.ts) — primitives stores compose with.
+- [src/schema/schemaPropFactory.ts](../src/schema/schemaPropFactory.ts) — `SchemaProp` shape that path-binding proxies conform to.
+- [src/view/external/repeat.ts](../src/view/external/repeat.ts) — keyed list reconciler integrated with store arrays.
+- [CLAUDE.md](../CLAUDE.md) §4, §5, §7 — project conventions and anti-patterns the design respects.

--- a/docs/STORE_IMPLEMENTATION_PLAN.md
+++ b/docs/STORE_IMPLEMENTATION_PLAN.md
@@ -1,38 +1,36 @@
-# Plan: `store()` — best-in-class deep reactivity for Marjoram
+# Plan: `store()` — deep reactivity for Marjoram
 
-> **Status:** Proposal / implementation plan. Not yet started.
-> **Owner:** TBD
-> **Last updated:** 2026-05-22
->
-> This is the cross-session reference for the deep-reactivity initiative. The eventual user-facing documentation lives at `docs/STORES.md` (to be written in Phase 1). This file is the *implementation* plan and design rationale.
+> **Status: ✅ Complete — all phases shipped in v1.1.0.** This is a historical record of how the deep-reactivity initiative was built (Phases 0–8 + a 7.5 review-remediation pass), kept for the design rationale and the versioning/non-breaking-change rules. **For the current public contract, see [STORES.md](STORES.md); for the "why" behind each decision, see [STORE_RESEARCH_FINDINGS.md](STORE_RESEARCH_FINDINGS.md).** This file is not a live roadmap.
 
 ## Context
 
-Marjoram currently exposes `signal()` (shallow, reference-based) as its only reactive primitive. Nested mutations (`vm.user.name = "x"`) don't trigger updates, forcing immutable-update patterns (`vm.user = { ...vm.user, name: "x" }`) that get painful at depth. The library has chosen explicitness as a core DX philosophy (`$prop` for reactive bindings vs. `prop` for values) — so the right answer is **not** to make all signals deep, but to add a *named peer primitive*: `store()`.
+Marjoram currently exposes `signal()` (shallow, reference-based) as its only reactive primitive. Nested mutations (`vm.user.name = "x"`) don't trigger updates, forcing immutable-update patterns (`vm.user = { ...vm.user, name: "x" }`) that get painful at depth. The library has chosen explicitness as a core DX philosophy (`$prop` for reactive bindings vs. `prop` for values) — so the right answer is **not** to make all signals deep, but to add a _named peer primitive_: `store()`.
 
-The bundle's ~5KB size is treated as a *result* of disciplined design, not a budget to optimize against. Quality and DX come first.
+The bundle's ~5KB size is treated as a _result_ of disciplined design, not a budget to optimize against. Quality and DX come first.
 
 ## Goal
 
-Add a `store()` primitive that lets users write `vm.user.address.city = "x"` and have only the subscribers to *that exact path* re-run. It must feel as natural as mutating a plain object, while remaining as predictable as `signal()`. No flags, no global modes — a named primitive that earns its place by being unambiguously better than the alternatives for nested state.
+Add a `store()` primitive that lets users write `vm.user.address.city = "x"` and have only the subscribers to _that exact path_ re-run. It must feel as natural as mutating a plain object, while remaining as predictable as `signal()`. No flags, no global modes — a named primitive that earns its place by being unambiguously better than the alternatives for nested state.
 
 ## Guiding principles (each one closes a known failure mode in a competitor)
 
-1. **Coherent with the `$` philosophy.** You opt into deep reactivity at the *import/constructor site*, not via a hidden flag. Reading `vm.$user.address.city` in a template means the exact same thing it always meant: "bind to a reactive value." Anyone reading the code can predict behavior.
+1. **Coherent with the `$` philosophy.** You opt into deep reactivity at the _import/constructor site_, not via a hidden flag. Reading `vm.$user.address.city` in a template means the exact same thing it always meant: "bind to a reactive value." Anyone reading the code can predict behavior.
 2. **Path-level granularity.** Mutating `state.user.name` notifies only `state.user.name` subscribers. Not `state.user`, not the root. This is what Vue 3, Valtio, and (with explicit paths) Solid all do correctly — and what MobX's "deep observable" can get wrong by waking too many observers.
 3. **Lazy proxying with stable identity.** Nested objects are only wrapped when accessed, and the wrapper is cached in a `WeakMap` so `state.user === state.user` across reads. This is the bug that bites consumers of naively-built proxy systems.
-4. **Hard boundaries on what gets proxied.** Plain objects and arrays only. `Date`, `Map`, `Set`, `RegExp`, `Promise`, DOM nodes, and any object with a non-`Object` prototype pass through *untouched*. Wrapping a `Date` because it's an object is the kind of "magic" that destroys trust.
+4. **Hard boundaries on what gets proxied.** Plain objects and arrays only. `Date`, `Map`, `Set`, `RegExp`, `Promise`, DOM nodes, and any object with a non-`Object` prototype pass through _untouched_. Wrapping a `Date` because it's an object is the kind of "magic" that destroys trust.
 5. **Reuses the existing subscriber machinery.** No parallel reactivity system. Each tracked path corresponds to a lightweight `SignalNode` (the same one in [src/reactivity/signal.ts](../src/reactivity/signal.ts)). That means `computed`, `effect`, `batch`, `untracked`, and the view layer's existing dependency tracking all work with zero special-casing.
 6. **Type-safe through arbitrary depth.** `Store<T>` preserves `T` exactly through the proxy. Reading `store.user.address.city` is typed `string`, not `unknown`. Tests assert this with `expectTypeOf`.
 7. **Predictable identity rules.** Assigning the same value (per `Object.is`) is a no-op. Replacing a subtree (`state.user = newUser`) reuses the existing proxy for `state.user` if the new value is structurally compatible, otherwise replaces it cleanly. Subscribers to paths that no longer exist are GC'd.
 
 ## Phase 0 — `repeat()` discoverability (warm-up)
 
-**Premise correction (2026-05-22):** `repeat` IS exported transitively via `src/view/index.ts` → `src/index.ts` (`export * from "./view"`), and the test at [__tests__/view/repeat.test.ts](../__tests__/view/repeat.test.ts) confirms it works. The real gap is *discoverability*:
+**Premise correction (2026-05-22):** `repeat` IS exported transitively via `src/view/index.ts` → `src/index.ts` (`export * from "./view"`), and the test at [**tests**/view/repeat.test.ts](../__tests__/view/repeat.test.ts) confirms it works. The real gap is _discoverability_:
+
 - No explicit `export { repeat }` line in [src/index.ts](../src/index.ts) — surfaces only through `export *` chains.
 - Not documented in [README.md](../README.md).
 
 Phase 0 therefore becomes:
+
 1. Add explicit named `export { repeat }` to [src/index.ts](../src/index.ts) (improves IDE go-to-definition, signals "this is public API" to readers).
 2. Add a `repeat()` section to [README.md](../README.md) with the example already in the JSDoc.
 3. Confirm the trio (`type-check`, `lint`, `test`) still passes.
@@ -43,7 +41,7 @@ Phase 0 therefore becomes:
 
 ## Phase 1 — Design doc (`docs/STORES.md`)
 
-Write this *before* any implementation. Sections:
+Write this _before_ any implementation. Sections:
 
 - **Mental model**: stores are "graph of signals, lazily projected through proxies."
 - **API surface**:
@@ -72,16 +70,16 @@ The patterns below are verified against competitor source in [STORE_RESEARCH_FIN
 Three well-known symbols on raw objects (Solid `store.ts:6-9` pattern, generalized):
 
 ```ts
-const $RAW    = Symbol("marjoram.raw");    // proxy → raw lookup via get-trap
-const $PROXY  = Symbol("marjoram.proxy");  // raw → proxy identity cache (defineProperty, non-enumerable)
-const $NODE   = Symbol("marjoram.node");   // raw → Record<key, SignalNode>, lazy
+const $RAW = Symbol("marjoram.raw"); // proxy → raw lookup via get-trap
+const $PROXY = Symbol("marjoram.proxy"); // raw → proxy identity cache (defineProperty, non-enumerable)
+const $NODE = Symbol("marjoram.node"); // raw → Record<key, SignalNode>, lazy
 ```
 
 Plus Vue-style flag keys ([Vue `constants.ts:11-24`](../../.research/vue/packages/reactivity/src/constants.ts)) intercepted in the `get` trap:
 
 ```ts
 const FLAG_IS_STORE = "__m_isStore";
-const FLAG_SKIP     = "__m_skip";        // markRaw bypass
+const FLAG_SKIP = "__m_skip"; // markRaw bypass
 ```
 
 ### Hot path — `get` trap
@@ -109,15 +107,20 @@ function get(raw: object, key: PropertyKey, receiver: object): unknown {
 ### Hot path — `set` trap
 
 ```ts
-function set(raw: object, key: PropertyKey, value: unknown, receiver: object): boolean {
+function set(
+  raw: object,
+  key: PropertyKey,
+  value: unknown,
+  receiver: object
+): boolean {
   const oldValue = (raw as any)[key];
   if (Object.is(oldValue, value)) return true;
   const isNewKey = !(key in raw);
   (raw as any)[key] = value;
-  notifyPath(raw, key);                  // SignalNode for this path
-  if (isNewKey) notifyKeys(raw);         // iteration sentinel on parent
+  notifyPath(raw, key); // SignalNode for this path
+  if (isNewKey) notifyKeys(raw); // iteration sentinel on parent
   if (typeof oldValue === "object" && oldValue !== null) {
-    invalidateProxy(oldValue);           // replaced subtree → drop $PROXY/$NODE
+    invalidateProxy(oldValue); // replaced subtree → drop $PROXY/$NODE
   }
   return true;
 }
@@ -206,7 +209,11 @@ The elegant move from [Solid `mutable.ts:55-58`](../../.research/solid/packages/
 
 ```ts
 // Inside the get-trap, before flag/raw checks:
-if (Array.isArray(raw) && typeof (raw as any)[key] === "function" && key in Array.prototype) {
+if (
+  Array.isArray(raw) &&
+  typeof (raw as any)[key] === "function" &&
+  key in Array.prototype
+) {
   const method = (raw as any)[key];
   return (...args: unknown[]) => batch(() => method.apply(receiver, args));
 }
@@ -225,10 +232,11 @@ Verified against [Valtio `vanilla.ts:64-76`](../../.research/valtio/src/vanilla.
 ```ts
 function shouldProxy(value: unknown): boolean {
   if (value === null || typeof value !== "object") return false;
-  if ((value as any)[FLAG_SKIP]) return false;            // markRaw
-  if (Object.isFrozen(value)) return false;                // frozen objects
+  if ((value as any)[FLAG_SKIP]) return false; // markRaw
+  if (Object.isFrozen(value)) return false; // frozen objects
   const proto = Object.getPrototypeOf(value);
-  if (proto !== Object.prototype && proto !== Array.prototype && proto !== null) return false;
+  if (proto !== Object.prototype && proto !== Array.prototype && proto !== null)
+    return false;
   return true;
 }
 ```
@@ -247,12 +255,12 @@ Reactive `Map`/`Set` variants are explicitly **out of scope** for v1.1 ([STORES.
 
 ## Phase 4 — Integration
 
-The point of building on existing primitives is that integration should be *trivial*:
+The point of building on existing primitives is that integration should be _trivial_:
 
 - **`html` templates**: `$store.user.name` returns a `SchemaProp`-equivalent reactive binding. Mechanism: when `$`-access on the store hits a leaf path, we wrap that path's `SignalNode` in the existing `SchemaProp` shape.
 - **`useViewModel`**: accepts stores as model values. Nested objects in a `useViewModel` definition automatically become stores (this is the one place where "deep by default" is the right call, because the user has already explicitly chosen `useViewModel`). **Pending decision** — see open questions.
 - **`repeat()`**: passing a reactive store array Just Works because `repeat` already consumes anything with `.value` + `.observe()`; we expose those on store-array bindings.
-- **`computed` / `effect` / `batch` / `untracked`**: zero changes required. They subscribe to `SignalNode`s; our paths *are* `SignalNode`s.
+- **`computed` / `effect` / `batch` / `untracked`**: zero changes required. They subscribe to `SignalNode`s; our paths _are_ `SignalNode`s.
 
 **Acceptance:** Integration tests pass. Existing `useViewModel`, `html`, `repeat()` tests still green. Demo widget using a store renders and updates granularly.
 
@@ -281,11 +289,17 @@ export function initStoreDevtoolsFormatter(): void {
       if (!isStore(obj)) return null;
       return ["div", {}, ["span", { style: "color:#3ba776" }, "Store"]];
     },
-    hasBody(obj: unknown) { return isStore(obj); },
+    hasBody(obj: unknown) {
+      return isStore(obj);
+    },
     body(obj: unknown) {
       // CRITICAL: unwrap to render the raw data, not the proxy.
       // Use untracked() so the formatter doesn't subscribe DevTools to the store.
-      return untracked(() => ["div", {}, ["object", { object: unwrap(obj as Store<object>) }]]);
+      return untracked(() => [
+        "div",
+        {},
+        ["object", { object: unwrap(obj as Store<object>) }],
+      ]);
     },
   };
 
@@ -296,6 +310,7 @@ export function initStoreDevtoolsFormatter(): void {
 ```
 
 Key implementation notes from reading Vue's version:
+
 - **`untracked()` wrap** any reactive reads inside the formatter. Vue uses `pauseTracking()`/`resetTracking()` ([`customFormatter.ts:40-42`](../../.research/vue/packages/runtime-core/src/customFormatter.ts)); we use the existing `untracked()` primitive.
 - **Production stripping** via Rollup `@rollup/plugin-replace` substituting `process.env.NODE_ENV` at build time. Confirm the existing Rollup config does this; add it if not.
 - **No "enable custom formatters" check needed in code** — that's a DevTools setting users toggle.
@@ -310,6 +325,7 @@ Current [rollup.config.js](../rollup.config.js) does **not** include `@rollup/pl
 ### Dev-mode warnings
 
 `process.env.NODE_ENV !== "production"` checks for:
+
 - Mutating during a `computed` body (use `effect` for side effects).
 - Setting a property to its current value (no-op; usually a code smell).
 - `unwrap(s)` + mutation pattern (silently bypasses reactivity).
@@ -339,7 +355,7 @@ Three layers, all in `__tests__/reactivity/store/`:
 
 1. **Parity tests**: port Solid's `createStore` test suite verbatim where applicable. If they pass, we're at table stakes.
 2. **Granularity assertions**: instrument `effect` runs and assert exact counts. "Setting `state.a.b` triggered N effects, expected 1."
-3. **Edge cases** ([__tests__/edge-cases/](../__tests__/edge-cases/)): cycles, deletion of subscribed paths, replacing a subtree, freezing, prototype pollution attempts, Symbol keys, getters on the source object, accessor descriptors, very deep trees (1000 levels) for stack safety.
+3. **Edge cases** ([**tests**/edge-cases/](../__tests__/edge-cases/)): cycles, deletion of subscribed paths, replacing a subtree, freezing, prototype pollution attempts, Symbol keys, getters on the source object, accessor descriptors, very deep trees (1000 levels) for stack safety.
 4. **Memory leak tests**: create + dispose 10k stores, assert heap doesn't grow (using `--expose-gc` and `process.memoryUsage()` deltas).
 5. **Type tests** via `expectTypeOf` for the depth-preservation claim.
 
@@ -347,7 +363,7 @@ Three layers, all in `__tests__/reactivity/store/`:
 
 ## Phase 7 — Benchmarks
 
-[__tests__/benchmarks/](../__tests__/benchmarks/) per the ratio-vs-baseline rules in [PERFORMANCE_TESTING_PHILOSOPHY.md](../PERFORMANCE_TESTING_PHILOSOPHY.md). Compare:
+[**tests**/benchmarks/](../__tests__/benchmarks/) per the ratio-vs-baseline rules in [PERFORMANCE_TESTING_PHILOSOPHY.md](../PERFORMANCE_TESTING_PHILOSOPHY.md). Compare:
 
 - `store` vs equivalent `signal`-only patterns (overhead measurement).
 - `store` vs Solid `createStore` (peer comparison).
@@ -362,7 +378,7 @@ Three layers, all in `__tests__/reactivity/store/`:
 - New `demo/nested-form/` example: a deeply-nested form editor that visibly proves only-the-edited-field re-renders. This is the demo that sells the feature.
 - Export `store`, `snapshot`, `subscribe`, `isStore`, `unwrap` from [src/index.ts](../src/index.ts). Export `repeat` (from Phase 0, but reconfirm).
 - Minor version bump (purely additive). Conventional commit `feat: add store() for deep reactivity`.
-- Bundle-size note in the PR description — *not as a budget check*, but as informational disclosure.
+- Bundle-size note in the PR description — _not as a budget check_, but as informational disclosure.
 
 **Acceptance:** Released to npm. Demo runs. README + STORES.md reflect final API.
 
@@ -372,18 +388,18 @@ Current: **v1.0.0**, manual versioning via `package.json` + `npm run release` (t
 
 Phased releases (all additive, all non-breaking by design):
 
-| Version | Phases | Scope | Bump |
-|---|---|---|---|
-| v1.0.1 | Phase 0 | Explicit `repeat` export + README docs | patch |
-| v1.1.0 | Phases 2 + 3 + 4 | `store()` core + array support + view-layer integration | minor |
-| v1.2.0 | Phases 5 + 6 + 7 | DX polish, full test suite, benchmarks | minor |
-| v1.2.x | Phase 8 | Demo + README finalization (may overlap into v1.2.0) | minor/patch |
+| Version | Phases           | Scope                                                   | Bump        |
+| ------- | ---------------- | ------------------------------------------------------- | ----------- |
+| v1.0.1  | Phase 0          | Explicit `repeat` export + README docs                  | patch       |
+| v1.1.0  | Phases 2 + 3 + 4 | `store()` core + array support + view-layer integration | minor       |
+| v1.2.0  | Phases 5 + 6 + 7 | DX polish, full test suite, benchmarks                  | minor       |
+| v1.2.x  | Phase 8          | Demo + README finalization (may overlap into v1.2.0)    | minor/patch |
 
 Phase 1 (design doc) does not ship to npm — it lands as a PR adding `docs/STORES.md`.
 
 ### Non-breaking-change rules (binding for this initiative)
 
-The whole point of `store()` being a *peer* primitive is that nothing existing changes. These rules are how we enforce that:
+The whole point of `store()` being a _peer_ primitive is that nothing existing changes. These rules are how we enforce that:
 
 1. **Signatures locked.** Do not modify the signature, generics, or return type of any of: `signal`, `computed`, `effect`, `batch`, `untracked`, `html`, `useViewModel`, `createWidget`, `when`, `repeat`, `SchemaProp`, `Signal`, `ReadonlySignal`.
 2. **Runtime semantics locked.** Existing code paths must produce byte-identical output and identical effect-fire counts before and after the change. Existing tests must pass unchanged.

--- a/docs/STORE_RESEARCH_FINDINGS.md
+++ b/docs/STORE_RESEARCH_FINDINGS.md
@@ -1,8 +1,9 @@
 # Store() Research Findings — Phase 1.5
 
-> **Status:** Findings from reading competitor source directly. Locks several design decisions in [STORES.md](STORES.md) and adds concrete implementation patterns to [STORE_IMPLEMENTATION_PLAN.md](STORE_IMPLEMENTATION_PLAN.md).
+> **Status: historical.** Findings from reading competitor source directly, captured before implementation. These shaped the v1.1.0 design; kept for the rationale. One decision below was later revised — see the note on §3. For the current public contract, see [STORES.md](STORES.md).
 >
 > **Sources read (with commit SHAs):**
+>
 > - **SolidJS** — `solidjs/solid` @ `128225942095f51f9b49a3f8fdc1bd7e3b9ee97b` — `packages/solid/store/src/{store.ts, mutable.ts, modifiers.ts}` (1092 LoC total)
 > - **Vue 3** — `vuejs/core` @ `bbdf86dcc6e3a8108c6313484ddfb52019b3e0e8` — `packages/reactivity/src/{dep.ts, reactive.ts, effect.ts, effectScope.ts, baseHandlers.ts, collectionHandlers.ts, arrayInstrumentations.ts, constants.ts}` (~3929 LoC)
 > - **Valtio** — `pmndrs/valtio` @ `706350c29948eb9f59ff6219b229365737218cd8` (v2.3.2) — `src/vanilla.ts` (459 LoC), utils
@@ -15,13 +16,14 @@
 
 Three competitors, three approaches:
 
-| Library | Mechanism |
-|---|---|
-| **Solid** | `$PROXY` symbol stashed via `Object.defineProperty(raw, $PROXY, { value: proxy })` — non-enumerable. `store.ts:49-84`. One symbol-property lookup per read. |
-| **Vue** | `proxyMap: WeakMap<Target, Proxy>` (`reactive.ts:26-35`). One WeakMap lookup per read. |
-| **Valtio** | `proxyCache: WeakMap<base, proxyObject>` (`vanilla.ts:172`). Same as Vue. |
+| Library    | Mechanism                                                                                                                                                   |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Solid**  | `$PROXY` symbol stashed via `Object.defineProperty(raw, $PROXY, { value: proxy })` — non-enumerable. `store.ts:49-84`. One symbol-property lookup per read. |
+| **Vue**    | `proxyMap: WeakMap<Target, Proxy>` (`reactive.ts:26-35`). One WeakMap lookup per read.                                                                      |
+| **Valtio** | `proxyCache: WeakMap<base, proxyObject>` (`vanilla.ts:172`). Same as Vue.                                                                                   |
 
 **Decision: Solid's `$PROXY` symbol approach.** Two reasons:
+
 - One fewer indirection on the hot path (symbol property read vs WeakMap.get).
 - No global mutable state — the cache lives on the raw object itself, GC's with the data.
 
@@ -53,7 +55,9 @@ function trackPath(raw: object, key: PropertyKey): void {
 
 **Leave**: Solid's separate `$HAS` symbol for `in`-check reactivity. We'll combine `in` and key-existence tracking into a single sentinel `keysNode` on the parent (Vue's `ITERATE_KEY` pattern, simplified).
 
-## 3. Flag-property pattern for `isStore`/`unwrap`/`markRaw` — LOCKED: Vue-style well-known string props
+## 3. Flag-property pattern for `isStore`/`unwrap`/`markRaw` — Vue-style flags
+
+> **Superseded by the 7.5a security pass:** this section originally locked Vue-style _string_ flag keys (`__m_isStore`/`__m_skip`). The pre-release security review found that string keys let untrusted JSON spoof store identity or escape reactivity, so the shipped implementation uses **`Symbol` flags** instead (JSON can't produce symbol keys). The get-trap interception pattern below is otherwise as shipped.
 
 Vue uses `ReactiveFlags` (`constants.ts:11-24`): `__v_isReactive`, `__v_isReadonly`, `__v_raw`, `__v_skip`, `__v_isShallow`. The base `get` handler (`baseHandlers.ts:66-85`) intercepts these and returns answers without going to the underlying data.
 
@@ -71,6 +75,7 @@ if (key === STORE_FLAGS.SKIP) return false; // would be set by markRaw
 ## 4. Batching — LOCKED: reuse existing `signal.ts` batch
 
 Marjoram's existing batch system ([src/reactivity/signal.ts:55-66, 256-266](../src/reactivity/signal.ts)) already implements:
+
 - `batchDepth` counter
 - `pendingNotifications: Set<Subscriber>` for de-duplication
 - Flush on outermost `endBatch`
@@ -85,7 +90,8 @@ Vue's batch (`effect.ts:247-310`) is the same shape, slightly more sophisticated
 ```ts
 // Solid mutable.ts:55-58 — the elegant move
 if (Array.isArray(target) && property in Array.prototype) {
-  return (...args) => batch(() => Array.prototype[property].apply(receiver, args));
+  return (...args) =>
+    batch(() => Array.prototype[property].apply(receiver, args));
 }
 ```
 
@@ -104,6 +110,7 @@ This is fine for Valtio because its primary consumer is React's `useSnapshot`, w
 **Decision: not for us.** Marjoram's reactive consumers are fine-grained DOM bindings without a re-track step. Per-path `SignalNode`s (Solid pattern, our existing direction) are strictly better for our case.
 
 **What to steal anyway** (orthogonal to invalidation strategy):
+
 - Microtask-batched subscribe with sync escape hatch (`vanilla.ts:330-341`) — useful for the `subscribe()` escape-hatch API; our `effect()` already uses microtask scheduling so this is consistent.
 - Lazy wiring of nested listeners only when a top-level listener exists (`vanilla.ts:239-245`) — the "reads are free" cousin.
 
@@ -114,18 +121,26 @@ Vue ships `customFormatter.ts` (212 LoC) in current `main` (Vue 3.5+). Confirms 
 ```ts
 // Our adaptation
 export function initStoreDevtoolsFormatter(): void {
-  if (typeof window === 'undefined') return;
-  if (process.env.NODE_ENV === 'production') return;
+  if (typeof window === "undefined") return;
+  if (process.env.NODE_ENV === "production") return;
 
   const formatter = {
     __marjoram_store_formatter: true, // identifier for "which library's formatter is this"
     header(obj: unknown) {
       if (!isStore(obj)) return null;
-      return ['div', {}, ['span', { style: 'color:#3ba776' }, 'Store'], ' ', formatRaw(obj)];
+      return [
+        "div",
+        {},
+        ["span", { style: "color:#3ba776" }, "Store"],
+        " ",
+        formatRaw(obj),
+      ];
     },
-    hasBody(obj: unknown) { return isStore(obj); },
+    hasBody(obj: unknown) {
+      return isStore(obj);
+    },
     body(obj: unknown) {
-      return ['div', {}, ['object', { object: unwrap(obj) }]]; // render raw
+      return ["div", {}, ["object", { object: unwrap(obj) }]]; // render raw
     },
   };
 
@@ -138,6 +153,7 @@ export function initStoreDevtoolsFormatter(): void {
 ```
 
 Key points (from reading Vue's implementation):
+
 - **Pause tracking inside the formatter** — reads during the formatter must not subscribe the devtools to the store. Vue uses `pauseTracking()`/`resetTracking()` (`customFormatter.ts:40-42`); we use `untracked(() => ...)`.
 - **Production stripping** — Vue uses `__DEV__` build-time constant. We use `process.env.NODE_ENV !== 'production'`, which Rollup's replace plugin can strip at build time. (Confirm during Phase 5 implementation.)
 - **No "enable custom formatters" check in code** — that's a DevTools setting users toggle once; we can't enable it programmatically.
@@ -152,35 +168,37 @@ type Primitive = string | number | boolean | bigint | symbol | null | undefined;
 type Builtin = Primitive | Date | RegExp | ((...a: any[]) => any);
 type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
-export type Path<T, D extends number = 10> =
-  [D] extends [never] ? never :
-  T extends Builtin ? never :
-  T extends ReadonlyArray<infer U>
-    ? `${number}` | `${number}.${Path<U, Prev[D]>}`
-    : T extends object
-      ? {
-          [K in keyof T & (string | number)]:
-            T[K] extends Builtin
+export type Path<T, D extends number = 10> = [D] extends [never]
+  ? never
+  : T extends Builtin
+    ? never
+    : T extends ReadonlyArray<infer U>
+      ? `${number}` | `${number}.${Path<U, Prev[D]>}`
+      : T extends object
+        ? {
+            [K in keyof T & (string | number)]: T[K] extends Builtin
               ? `${K}`
               : `${K}` | `${K}.${Path<NonNullable<T[K]>, Prev[D]>}`;
-        }[keyof T & (string | number)]
-      : never;
-
-export type PathValue<T, P extends string> =
-  P extends `${infer K}.${infer R}`
-    ? K extends keyof NonNullable<T>
-      ? PathValue<NonNullable<T>[K], R> | (undefined extends T ? undefined : never)
-      : NonNullable<T> extends ReadonlyArray<infer U>
-        ? PathValue<U, R> | (undefined extends T ? undefined : never)
-        : never
-    : P extends keyof NonNullable<T>
-      ? NonNullable<T>[P] | (undefined extends T ? undefined : never)
-      : NonNullable<T> extends ReadonlyArray<infer U>
-        ? U | (undefined extends T ? undefined : never)
+          }[keyof T & (string | number)]
         : never;
+
+export type PathValue<T, P extends string> = P extends `${infer K}.${infer R}`
+  ? K extends keyof NonNullable<T>
+    ?
+        | PathValue<NonNullable<T>[K], R>
+        | (undefined extends T ? undefined : never)
+    : NonNullable<T> extends ReadonlyArray<infer U>
+      ? PathValue<U, R> | (undefined extends T ? undefined : never)
+      : never
+  : P extends keyof NonNullable<T>
+    ? NonNullable<T>[P] | (undefined extends T ? undefined : never)
+    : NonNullable<T> extends ReadonlyArray<infer U>
+      ? U | (undefined extends T ? undefined : never)
+      : never;
 ```
 
 **Caveats** (to document in STORES.md for users):
+
 1. Depth cap of 10 by default. Deeper requires bumping `Prev` tuple and accepting compile-time cost.
 2. Arrays use dot-numeric paths only (`"items.0.name"`), not brackets (`"items[0].name"`).
 3. Discriminated unions distribute keys but lose discriminator correlation (no `Path<T>` library solves this; it would require correlated-union techniques from Hejlsberg's `microsoft/TypeScript#47109`).
@@ -218,10 +236,10 @@ Replace the generic "Proxy handler, lazy nested proxying, path-level SignalNodes
 
 ## 12. Open questions now closed
 
-| ID | Question | Resolution |
-|---|---|---|
-| §11 #1 | `produce`-style transactions? | **No.** `batch()` covers it. Locked. |
+| ID     | Question                                                 | Resolution                                           |
+| ------ | -------------------------------------------------------- | ---------------------------------------------------- |
+| §11 #1 | `produce`-style transactions?                            | **No.** `batch()` covers it. Locked.                 |
 | §11 #2 | Method-vs-data collision policy on path-binding proxies? | **Method wins, dev warning.** Vue precedent. Locked. |
-| §11 #3 | `subscribe()` accepts a path filter? | **Yes — typed path.** Use `Path<T>` from §8. Locked. |
+| §11 #3 | `subscribe()` accepts a path filter?                     | **Yes — typed path.** Use `Path<T>` from §8. Locked. |
 
 [STORES.md](STORES.md) §14 (Open Questions) is now empty. Phase 2 can begin without further design discussion.


### PR DESCRIPTION
## Summary

Review pass over the `store()` documentation for conciseness, navigability, and accuracy now that v1.1.0 has shipped. **Docs-only — no source changes.**

## `docs/STORES.md` (canonical contract)

- **Added a Contents section + "Quick links" bar.** Verified every in-doc anchor resolves to a real heading slug (GitHub-accurate slugifier check).
- **Removed the `(audience: …)` tag from ~12 headings** — repetitive noise; replaced with one note up top.
- **Fixed a real inaccuracy:** §4 documented `store(initial, options?)` + a `StoreOptions { name }` interface that **were never implemented**. The shipped API is `store(initial)`. Removed the phantom param/interface; renamed §4.1.
- **De-proposalized the prose** — present tense throughout; status header is "Shipped in v1.1.0".
- **Removed the resolved "Open questions" section** (all four answered during the build); renumbered Worked examples → §14, Cross-references → §15, updated all refs.
- Simplified two headings whose trailing text broke their anchors.

## Internal history docs

- `STORE_IMPLEMENTATION_PLAN.md` / `STORE_RESEARCH_FINDINGS.md` now carry **"complete / historical" banners** so they read as the build record + rationale, not live roadmaps, and point to STORES.md for the current contract.
- Noted that the research doc's §3 "string flag keys" decision was **superseded by the 7.5a security pass** (flags are Symbols).

## Not touched

README `store()` section and CHANGELOG were written against the shipped API in #25 — accurate and concise, no edits needed.

## Note

Independent of the still-open release PR #25 (no file overlap). Either can merge first.