### PR TITLE
feat(reactivity): v1.2 — TC39-Signals-aligned primitives + store on public surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,73 @@
 All notable changes to Marjoram are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] — 2026-06-01
+
+Additive, non-breaking. Aligns the reactivity layer with the
+[TC39 Signals proposal](https://github.com/tc39/proposal-signals): adds
+`SignalOptions`, lifecycle hooks, a `Signal.subtle.Watcher`-shaped primitive,
+and an introspection namespace. Internals switch from a dirty flag to
+epoch/version memoization with skip-on-stale for both computeds and effects.
+
+`store()` is rebuilt on these public primitives — no internal escape hatches
+into the reactivity engine — proving the spec surface is sufficient for deep
+reactivity.
+
+### Added
+
+- **`SignalOptions<T>`** — second arg to `signal()` and `computed()`:
+  - `equals?: (a, b) => boolean` — overrides `Object.is` when deciding
+    whether a write/recompute actually changed the value.
+  - `[Signal.subtle.watched]` / `[Signal.subtle.unwatched]` — lifecycle
+    callbacks that fire on the 0↔1 live-watcher transition. Hook callbacks
+    must not read or write signals (dev-mode I/O assertion, stripped in
+    production).
+- **`watcher(notify)`** — TC39 `Signal.subtle.Watcher`-shaped low-level
+  observer. `notify` fires synchronously when a watched signal becomes
+  stale; for everyday side effects, keep using `effect()`.
+- **`Signal.subtle` namespace** — spec-shaped introspection and lifecycle
+  symbols:
+  - `watched` / `unwatched` (option keys)
+  - `untrack(fn)` (alias for `untracked`)
+  - `currentComputed()` — the computed currently being evaluated, or `null`
+  - `introspectSources(target)` / `introspectSinks(target)`
+  - `hasSources(target)` / `hasSinks(target)`
+  - `isTracking()` — small Marjoram extension for reactive containers
+- **Dual API on signal callables** — `.get()` / `.set()` / `.peek()` exist
+  alongside the callable form (`s()` / `s.set(v)`). The callable stays the
+  documented DX surface; the methods are for interop with anything written
+  against the spec or `signal-utils`.
+
+### Changed
+
+- **Computed memoization** uses epoch/version comparison instead of a dirty
+  flag. Recompute is skipped when no source's version has actually changed
+  since the last evaluation — invisible in single-source graphs, can
+  legitimately reduce re-runs in multi-source/diamond shapes.
+- **Effects** push-pull on microtask: if no source's version moved (e.g.
+  because an upstream computed's `equals` returned `true`), the effect skips
+  re-running entirely.
+- **Cycle detection now throws.** Reading a computed during its own
+  evaluation throws `Cycle detected`. Previously the read silently returned
+  a stale value.
+- **`store()` is rebuilt on public primitives.** Per-path tracking nodes are
+  real `signal(undefined, { equals: () => false, [unwatched]: ... })`. The
+  `[unwatched]` hook reclaims a path slot when its last live consumer
+  disconnects (and no non-live computed reader is still observing). The
+  internal `_isTracking`/`_createNode`/`_track`/`_notify` escape hatches
+  that earlier versions exposed have been removed.
+
+### Notes
+
+- Bundle: ~6.8 KB gzipped (UMD/ESM), zero runtime dependencies. ~1 KB
+  growth over 1.1 for the spec-shaped additions; the DevTools formatter
+  is still dead-code-eliminated from production builds.
+- Honest framing: this is spec-shape-compatible with `[watched]/[unwatched]`
+  lifecycle and a Watcher primitive. It is **not** a pull-based glitch-free
+  evaluation graph (Reactively / alien-signals style); push-based propagation
+  is preserved. "TC39-aligned reference implementation" is defensible;
+  "fastest signals engine in JS" is not.
+
 ## [1.1.0] — 2026-05-29
 
 Additive, non-breaking. Adds deep reactivity as a peer to `signal()`. No

--- a/README.md
+++ b/README.md
@@ -981,6 +981,53 @@ batch(() => {
 dispose(); // stop the effect
 ```
 
+#### Spec-shaped surface (v1.2+)
+
+Marjoram's reactivity layer mirrors the
+[TC39 Signals proposal](https://github.com/tc39/proposal-signals). The
+callable form (`s()` / `s.set(v)`) is the documented DX; the spec-shaped
+methods and `Signal.subtle.*` namespace exist for interop and advanced use:
+
+```typescript
+import { signal, computed, watcher, Signal } from "marjoram";
+
+// .get() / .set() / .peek() — spec-shaped methods on every signal callable
+const count = signal(0);
+count.get(); // 0  (same as count())
+count.set(1);
+count.peek(); // 1 — no tracking
+
+// SignalOptions: per-signal equality + lifecycle hooks
+const user = signal(
+  { id: 1, name: "Alice" },
+  {
+    equals: (a, b) => a.id === b.id,
+    [Signal.subtle.watched]: () => console.log("first consumer arrived"),
+    [Signal.subtle.unwatched]: () => console.log("last consumer left"),
+  }
+);
+
+// Low-level synchronous observer — for custom schedulers; prefer effect()
+const w = watcher(() => {
+  // notify cannot read or write signals (dev-mode throws)
+  for (const s of w.getPending()) {
+    /* schedule something */
+  }
+});
+w.watch(count);
+w.dispose();
+
+// Introspection
+Signal.subtle.hasSinks(count); // boolean — anyone observing?
+Signal.subtle.introspectSources(c); // sources of a computed
+Signal.subtle.currentComputed(); // the computed currently being evaluated
+Signal.subtle.isTracking(); // are we inside any tracked context?
+Signal.subtle.untrack(fn); // same as untracked(fn)
+```
+
+`store()` itself is built on this surface — every per-path tracker is a real
+`signal()` with `equals: () => false` and an `[unwatched]` hook for lazy GC.
+
 ### How it works under the hood
 
 1. **`useViewModel`** wraps each model property in a `signal`

--- a/__tests__/reactivity/adversarial.test.ts
+++ b/__tests__/reactivity/adversarial.test.ts
@@ -1,0 +1,349 @@
+import {
+  signal,
+  computed,
+  effect,
+  watcher,
+  store,
+  Signal,
+  type ReadonlySignal,
+} from "../../src/reactivity";
+
+const flush = () => new Promise<void>(r => queueMicrotask(r));
+
+describe("Adversarial probes", () => {
+  describe("hasSinks vs introspectSinks consistency", () => {
+    it("agrees when only computeds subscribe", () => {
+      const s = signal(0);
+      const c = computed(() => s() * 2);
+      c();
+      expect(Signal.subtle.hasSinks(s)).toBe(true);
+      expect(Signal.subtle.introspectSinks(s).length).toBe(1);
+    });
+
+    it("hasSinks is false for effect-only observers (spec-shaped); hasObservers is true", () => {
+      const s = signal(0);
+      const dispose = effect(() => {
+        s();
+      });
+      // Effects are not first-class spec entities, so they don't appear
+      // in introspectSinks / hasSinks. Marjoram exposes `hasObservers` to
+      // count any subscriber type.
+      expect(Signal.subtle.hasSinks(s)).toBe(false);
+      expect(Signal.subtle.introspectSinks(s).length).toBe(0);
+      expect(Signal.subtle.hasObservers(s)).toBe(true);
+      dispose();
+      expect(Signal.subtle.hasObservers(s)).toBe(false);
+    });
+  });
+
+  describe("Path-signal GC under mixed live + non-live observers", () => {
+    it("does NOT delete path node when a non-live computed is still subscribed", async () => {
+      const raw: { x: number } = { x: 1 };
+      const s = store(raw);
+      const c = computed(() => s.x); // non-live computed
+      c();
+      const dispose = effect(() => { s.x; }); // live consumer
+      // Both reading state.x. Path signal exists, watcherCount = 1.
+      dispose();
+      // After effect disposes, [unwatched] fires on path signal.
+      // Computed is still subscribed → path signal should NOT be GC'd.
+      s.x = 2;
+      // Computed should still respond to mutation.
+      expect(c()).toBe(2);
+    });
+  });
+
+  describe("Multi-effect lifecycle hook count", () => {
+    it("[watched] fires exactly once even with multiple consumers", () => {
+      let watched = 0;
+      let unwatched = 0;
+      const s = signal(1, {
+        [Signal.subtle.watched]: () => { watched++; },
+        [Signal.subtle.unwatched]: () => { unwatched++; },
+      });
+      const d1 = effect(() => { s(); });
+      const d2 = effect(() => { s(); });
+      const d3 = effect(() => { s(); });
+      expect(watched).toBe(1);
+      expect(unwatched).toBe(0);
+      d1();
+      d2();
+      expect(watched).toBe(1);
+      expect(unwatched).toBe(0); // count still > 0
+      d3();
+      expect(unwatched).toBe(1); // last one
+    });
+  });
+
+  describe("Re-subscribe transitions", () => {
+    it("[watched]/[unwatched] cycle correctly through repeated subscribe/dispose", () => {
+      const log: string[] = [];
+      const s = signal(1, {
+        [Signal.subtle.watched]: () => log.push("watched"),
+        [Signal.subtle.unwatched]: () => log.push("unwatched"),
+      });
+      const d1 = effect(() => { s(); });
+      d1();
+      const d2 = effect(() => { s(); });
+      d2();
+      expect(log).toEqual(["watched", "unwatched", "watched", "unwatched"]);
+    });
+  });
+
+  describe("Diamond dedup with versioning", () => {
+    it("effect downstream of a no-op computed (equals=true) skips re-run", async () => {
+      const s = signal(0);
+      const c = computed(() => ({ neg: s() < 0 }), {
+        equals: (a, b) => a.neg === b.neg,
+      });
+      let runs = 0;
+      effect(() => {
+        c();
+        runs++;
+      });
+      expect(runs).toBe(1);
+      // Source moves, but `neg` result stays the same → effect should not re-run.
+      s.set(5);
+      await flush();
+      expect(runs).toBe(1);
+      s.set(-1); // now neg flips
+      await flush();
+      expect(runs).toBe(2);
+    });
+  });
+
+  describe("Cycle: indirect via two computeds", () => {
+    it("throws when c1 → c2 → c1", () => {
+      const trigger = signal(0);
+      // Forward refs so each fn body can read the other.
+      /* eslint-disable prefer-const */
+      let c1: ReadonlySignal<number>;
+      let c2: ReadonlySignal<number>;
+      c2 = computed(() => {
+        if (trigger() > 0) return c1();
+        return 1;
+      });
+      c1 = computed(() => {
+        if (trigger() > 0) return c2();
+        return 0;
+      });
+      /* eslint-enable prefer-const */
+      // Initial: both eval without recursion.
+      expect(c1()).toBe(0);
+      expect(c2()).toBe(1);
+      // Trigger the cycle.
+      trigger.set(1);
+      expect(() => c1()).toThrow(/Cycle detected/);
+    });
+  });
+
+  describe("Watcher pending tracking", () => {
+    it("getPending returns moved sources after notify", () => {
+      const s = signal(1);
+      const c = computed(() => s() * 2);
+      const log: string[] = [];
+      const w = watcher(() => log.push("notify"));
+      w.watch(c);
+      expect(w.getPending()).toEqual([]);
+      s.set(5);
+      expect(log).toEqual(["notify"]);
+      expect(w.getPending()).toEqual([c]);
+      w.dispose();
+    });
+  });
+
+  describe("Signal write inside notify throws", () => {
+    it("write inside notify is rejected in dev mode", () => {
+      const s = signal(0);
+      const w = watcher(() => {
+        s.set(99); // illegal
+      });
+      w.watch(s);
+      expect(() => s.set(1)).toThrow(/Cannot write a signal/);
+      w.dispose();
+    });
+  });
+
+  describe("Effect inside batch doesn't re-run between writes", () => {
+    it("multiple writes batch into one re-run", async () => {
+      const a = signal(0);
+      const b = signal(0);
+      let runs = 0;
+      effect(() => {
+        a(); b();
+        runs++;
+      });
+      expect(runs).toBe(1);
+      // batch then await flush.
+      // We need the batch import. Use a fresh import.
+      const { batch } = await import("../../src/reactivity");
+      batch(() => {
+        a.set(1);
+        a.set(2);
+        b.set(3);
+      });
+      await flush();
+      expect(runs).toBe(2);
+    });
+  });
+
+  describe("Disposing an already-disposed effect doesn't crash", () => {
+    it("double dispose is safe", () => {
+      const s = signal(0);
+      const dispose = effect(() => {
+        s();
+      });
+      dispose();
+      expect(() => dispose()).not.toThrow();
+    });
+  });
+
+  describe("Frozen callback throws — state restoration", () => {
+    it("activeSubscriber/inFrozenCallback restored after notify throws", () => {
+      const s = signal(0);
+      const w = watcher(() => {
+        throw new Error("hook boom");
+      });
+      w.watch(s);
+      expect(() => s.set(1)).toThrow(/hook boom/);
+      // After the throw, normal reads/writes should work fine again.
+      const after = signal(0);
+      let runs = 0;
+      const dispose = effect(() => {
+        after();
+        runs++;
+      });
+      expect(runs).toBe(1);
+      after.set(1);
+      return flush().then(() => {
+        expect(runs).toBe(2);
+        dispose();
+        w.dispose();
+      });
+    });
+  });
+
+  describe("Watcher count propagation through deep computed chain", () => {
+    it("transitively bumps and decrements through 3-level chain", () => {
+      const events: string[] = [];
+      const sig = signal(1, {
+        [Signal.subtle.watched]: () => events.push("sig.watched"),
+        [Signal.subtle.unwatched]: () => events.push("sig.unwatched"),
+      });
+      const a = computed(() => sig() + 1);
+      const b = computed(() => a() + 1);
+      const c = computed(() => b() + 1);
+      // No live consumer yet — chain is dormant.
+      expect(events).toEqual([]);
+      // Effect on c → all three computeds become live → sig becomes live.
+      const dispose = effect(() => {
+        c();
+      });
+      expect(events).toEqual(["sig.watched"]);
+      dispose();
+      expect(events).toEqual(["sig.watched", "sig.unwatched"]);
+    });
+  });
+
+  describe("Multiple watchers on the same signal", () => {
+    it("count goes to 2; [watched] fires only on 0→1", () => {
+      let watchedCount = 0;
+      let unwatchedCount = 0;
+      const s = signal(0, {
+        [Signal.subtle.watched]: () => watchedCount++,
+        [Signal.subtle.unwatched]: () => unwatchedCount++,
+      });
+      const w1 = watcher(() => {});
+      const w2 = watcher(() => {});
+      w1.watch(s);
+      expect(watchedCount).toBe(1);
+      w2.watch(s);
+      expect(watchedCount).toBe(1); // still 1 — already live
+      w1.dispose();
+      expect(unwatchedCount).toBe(0); // still live (w2)
+      w2.dispose();
+      expect(unwatchedCount).toBe(1);
+    });
+  });
+
+  describe("Reading a computed inside untracked()", () => {
+    it("does not register as a dependency", async () => {
+      const s = signal(1);
+      const c = computed(() => s() * 10);
+      let runs = 0;
+      effect(() => {
+        Signal.subtle.untrack(() => {
+          c();
+        });
+        runs++;
+      });
+      expect(runs).toBe(1);
+      s.set(5);
+      await flush();
+      // Effect did not subscribe to c (or transitively s), so no re-run.
+      expect(runs).toBe(1);
+    });
+  });
+
+  describe("Dynamic deps: computed switching sources mid-life", () => {
+    it("[unwatched] fires on dropped source, [watched] on new", () => {
+      const events: string[] = [];
+      const a = signal(1, {
+        [Signal.subtle.watched]: () => events.push("a.watched"),
+        [Signal.subtle.unwatched]: () => events.push("a.unwatched"),
+      });
+      const b = signal(2, {
+        [Signal.subtle.watched]: () => events.push("b.watched"),
+        [Signal.subtle.unwatched]: () => events.push("b.unwatched"),
+      });
+      const which = signal<"a" | "b">("a");
+      const c = computed(() => (which() === "a" ? a() : b()));
+      const dispose = effect(() => {
+        c();
+      });
+      expect(events).toContain("a.watched");
+      expect(events).not.toContain("b.watched");
+      // Flip the branch. Computed re-evaluates synchronously on next read.
+      which.set("b");
+      return flush().then(() => {
+        expect(events).toContain("a.unwatched");
+        expect(events).toContain("b.watched");
+        dispose();
+      });
+    });
+  });
+
+  describe("Watching a disposed signal", () => {
+    it("does not throw; just doesn't fire", () => {
+      const s = signal(1);
+      s.dispose();
+      const w = watcher(() => {});
+      // Disposed signals are still in the registry — watching them is legal,
+      // just doesn't observe future writes (no notify path exists).
+      expect(() => w.watch(s)).not.toThrow();
+      w.dispose();
+    });
+  });
+
+  describe("Computed read inside batch", () => {
+    it("re-evaluates correctly after batch completes", async () => {
+      const a = signal(1);
+      const b = signal(2);
+      const c = computed(() => a() + b());
+      let runs = 0;
+      effect(() => {
+        c();
+        runs++;
+      });
+      expect(runs).toBe(1);
+      const { batch } = await import("../../src/reactivity");
+      batch(() => {
+        a.set(10);
+        b.set(20);
+      });
+      await flush();
+      expect(runs).toBe(2);
+      expect(c()).toBe(30);
+    });
+  });
+});

--- a/__tests__/reactivity/spec-surface.test.ts
+++ b/__tests__/reactivity/spec-surface.test.ts
@@ -1,0 +1,220 @@
+import {
+  signal,
+  computed,
+  effect,
+  watcher,
+  Signal,
+  type Signal as SignalT,
+  type ReadonlySignal,
+} from "../../src/reactivity";
+
+const flush = () => new Promise<void>(resolve => queueMicrotask(resolve));
+
+describe("Spec-shaped surface (Phase 3+4)", () => {
+  describe("SignalOptions.equals", () => {
+    it("suppresses notifications when equals returns true", async () => {
+      const s = signal({ x: 1 }, { equals: (a, b) => a.x === b.x });
+      let runs = 0;
+      effect(() => {
+        s();
+        runs++;
+      });
+      expect(runs).toBe(1);
+      s.set({ x: 1 }); // same logical value
+      await flush();
+      expect(runs).toBe(1);
+      s.set({ x: 2 });
+      await flush();
+      expect(runs).toBe(2);
+    });
+
+    it("works on computed too", async () => {
+      const s = signal(1);
+      const c = computed(() => ({ doubled: s() * 2 }), {
+        equals: (a, b) => a.doubled === b.doubled,
+      });
+      let runs = 0;
+      effect(() => {
+        c();
+        runs++;
+      });
+      expect(runs).toBe(1);
+      // Set source to something that yields the same computed result via equals
+      s.set(1);
+      await flush();
+      expect(runs).toBe(1);
+    });
+  });
+
+  describe("[Signal.subtle.watched] / [Signal.subtle.unwatched]", () => {
+    it("fires watched on 0→1 transition, unwatched on 1→0", () => {
+      const events: string[] = [];
+      const s = signal(1, {
+        [Signal.subtle.watched]: () => events.push("watched"),
+        [Signal.subtle.unwatched]: () => events.push("unwatched"),
+      });
+      expect(events).toEqual([]);
+      const dispose = effect(() => {
+        s();
+      });
+      expect(events).toEqual(["watched"]);
+      dispose();
+      expect(events).toEqual(["watched", "unwatched"]);
+    });
+
+    it("does not double-fire when adding a second consumer", () => {
+      const events: string[] = [];
+      const s = signal(1, {
+        [Signal.subtle.watched]: () => events.push("watched"),
+      });
+      const d1 = effect(() => {
+        s();
+      });
+      const d2 = effect(() => {
+        s();
+      });
+      expect(events).toEqual(["watched"]);
+      d1();
+      d2();
+    });
+
+    it("propagates transitively through computed", () => {
+      const events: string[] = [];
+      const s = signal(1, {
+        [Signal.subtle.watched]: () => events.push("watched"),
+        [Signal.subtle.unwatched]: () => events.push("unwatched"),
+      });
+      const c = computed(() => s() * 2);
+      // No live consumer yet — computed alone does NOT make s "watched"
+      expect(events).toEqual([]);
+      const dispose = effect(() => {
+        c();
+      });
+      expect(events).toEqual(["watched"]);
+      dispose();
+      expect(events).toEqual(["watched", "unwatched"]);
+    });
+
+    it("forbids signal I/O inside a lifecycle hook (dev mode)", () => {
+      const s = signal(1, {
+        [Signal.subtle.watched]: () => {
+          s(); // illegal
+        },
+      });
+      expect(() =>
+        effect(() => {
+          s();
+        })
+      ).toThrow(/Cannot read a signal/);
+    });
+  });
+
+  describe("Signal.subtle introspection", () => {
+    it("currentComputed returns the active computed during evaluation", () => {
+      let seen: ReadonlySignal<unknown> | null = "untouched" as unknown as null;
+      const s = signal(1);
+      const c = computed(() => {
+        seen = Signal.subtle.currentComputed();
+        return s();
+      });
+      c(); // force evaluation
+      expect(seen).toBe(c);
+      expect(Signal.subtle.currentComputed()).toBe(null);
+    });
+
+    it("introspectSources / hasSources reflect the dependency set", () => {
+      const a = signal(1);
+      const b = signal(2);
+      const c = computed(() => a() + b());
+      c();
+      const sources = Signal.subtle.introspectSources(c);
+      expect(sources).toContain(a);
+      expect(sources).toContain(b);
+      expect(Signal.subtle.hasSources(c)).toBe(true);
+    });
+
+    it("introspectSinks / hasSinks reflect downstream subscribers", () => {
+      const a = signal(1);
+      const c = computed(() => a() * 2);
+      c(); // wire up
+      const sinks = Signal.subtle.introspectSinks(a);
+      expect(sinks).toContain(c);
+      expect(Signal.subtle.hasSinks(a)).toBe(true);
+    });
+
+    it("untrack is an alias for untracked", () => {
+      const s = signal(1);
+      let runs = 0;
+      effect(() => {
+        Signal.subtle.untrack(() => s());
+        runs++;
+      });
+      expect(runs).toBe(1);
+      s.set(2);
+      return flush().then(() => expect(runs).toBe(1));
+    });
+  });
+
+  describe("Dual API surface (.get / .set / .peek)", () => {
+    it("signal exposes both callable and .get/.set/.peek", () => {
+      const s: SignalT<number> = signal(10);
+      expect(s()).toBe(10);
+      expect(s.get()).toBe(10);
+      s.set(20);
+      expect(s()).toBe(20);
+      expect(s.get()).toBe(20);
+      expect(s.peek()).toBe(20);
+    });
+
+    it("computed exposes both callable and .get/.peek", () => {
+      const s = signal(3);
+      const c = computed(() => s() * 2);
+      expect(c()).toBe(6);
+      expect(c.get()).toBe(6);
+      expect(c.peek()).toBe(6);
+    });
+
+    it(".get is reactive-tracking just like calling the signal", async () => {
+      const s = signal(1);
+      let runs = 0;
+      effect(() => {
+        s.get();
+        runs++;
+      });
+      expect(runs).toBe(1);
+      s.set(2);
+      await flush();
+      expect(runs).toBe(2);
+    });
+  });
+
+  describe("Cycle detection", () => {
+    it("throws when a computed reads itself during evaluation", () => {
+      // Initial eval doesn't recurse — only after we flip the trigger.
+      const trigger = signal(0);
+      /* eslint-disable prefer-const */
+      let c: ReadonlySignal<number>;
+      c = computed(() => {
+        const t = trigger();
+        if (t > 0) return c();
+        return 0;
+      });
+      /* eslint-enable prefer-const */
+      expect(c()).toBe(0);
+      trigger.set(1);
+      expect(() => c()).toThrow(/Cycle detected/);
+    });
+  });
+
+  describe("Watcher dev-mode I/O", () => {
+    it("throws when notify tries to write a signal", () => {
+      const s = signal(1);
+      const w = watcher(() => {
+        s.set(99);
+      });
+      w.watch(s);
+      expect(() => s.set(2)).toThrow(/Cannot write a signal/);
+      w.dispose();
+    });
+  });
+});

--- a/__tests__/reactivity/store-coverage-gaps.test.ts
+++ b/__tests__/reactivity/store-coverage-gaps.test.ts
@@ -10,6 +10,7 @@ import {
   batch,
   isStore,
   markRaw,
+  Signal,
 } from "../../src/reactivity";
 import { useViewModel } from "../../src";
 
@@ -20,18 +21,20 @@ const flushTwice = async () => {
 };
 
 const NODE_SYM_DESC = "marjoram.node";
-function nodeFor(
+function pathSignalFor(
   raw: object,
   key: string
-): { _subscribers: Set<unknown> } | undefined {
+): Signal<undefined> | undefined {
   const sym = Object.getOwnPropertySymbols(raw).find(
     s => s.description === NODE_SYM_DESC
   );
   if (!sym) return undefined;
-  const nodes = (
-    raw as Record<symbol, Record<string, { _subscribers: Set<unknown> }>>
-  )[sym];
-  return nodes[key];
+  // After v1.2 the per-path tracker is a real signal() — return it so
+  // tests can use the public `Signal.subtle.introspectSinks` to inspect it.
+  const nodes = (raw as Record<symbol, Record<string, Signal<undefined>>>)[
+    sym
+  ];
+  return nodes?.[key];
 }
 
 describe("store() coverage gaps (Phase 7.5c)", () => {
@@ -252,16 +255,28 @@ describe("store() coverage gaps (Phase 7.5c)", () => {
   });
 
   describe("subscription de-dup and multi-effect fan-in", () => {
-    it("reading the same path twice in one effect registers a single subscriber", () => {
+    it("reading the same path twice in one effect registers a single subscriber", async () => {
       const raw = { x: 1 };
       const s = store(raw);
+      let runs = 0;
       effect(() => {
         s.x;
         s.x; // read twice
+        runs++;
       });
-      const node = nodeFor(raw, "x");
-      expect(node).toBeDefined();
-      expect(node!._subscribers.size).toBe(1);
+      expect(runs).toBe(1);
+      // One write → one effect run; if reads double-subscribed, we'd see 2.
+      s.x = 2;
+      await flush();
+      expect(runs).toBe(2);
+
+      // Per-path signal exists and has observers — verifies the store is
+      // using public signals end-to-end (Phase 5 demo). The effect is not
+      // a spec-shaped sink, so we check `hasObservers` (any subscriber),
+      // not `hasSinks` (computed/watcher only).
+      const pathSig = pathSignalFor(raw, "x");
+      expect(pathSig).toBeDefined();
+      expect(Signal.subtle.hasObservers(pathSig!)).toBe(true);
     });
 
     it("N effects on the same path each re-run exactly once per change", async () => {

--- a/__tests__/reactivity/watcher.test.ts
+++ b/__tests__/reactivity/watcher.test.ts
@@ -1,0 +1,70 @@
+import { signal, computed, effect, watcher } from "../../src/reactivity";
+
+describe("Watcher smoke", () => {
+  it("fires notify when a watched signal moves", () => {
+    const s = signal(1);
+    let calls = 0;
+    const w = watcher(() => { calls++; });
+    w.watch(s);
+    expect(calls).toBe(0);
+    s.set(2);
+    expect(calls).toBe(1);
+    s.set(3);
+    expect(calls).toBe(2);
+    w.dispose();
+    s.set(4);
+    expect(calls).toBe(2);
+  });
+
+  it("propagates watcherCount through computed (transitively)", () => {
+    // Effect (live consumer) watching a computed that reads a signal —
+    // signal should see watcher-count > 0 by transitivity.
+    const s = signal(10);
+    let runs = 0;
+    const dispose = effect(() => {
+      s();
+      runs++;
+    });
+    expect(runs).toBe(1);
+    s.set(11);
+    return new Promise<void>(r => queueMicrotask(() => {
+      expect(runs).toBe(2);
+      dispose();
+      r();
+    }));
+  });
+
+  it("forbids signal I/O inside notify (dev mode)", () => {
+    const s = signal(1);
+    const w = watcher(() => {
+      s(); // illegal
+    });
+    w.watch(s);
+    expect(() => s.set(2)).toThrow(/Cannot read a signal inside a Watcher notify/);
+    w.dispose();
+  });
+
+  it("getPending returns watched signals that moved", () => {
+    const s = signal(1);
+    const c = computed(() => s() * 2);
+    const w = watcher(() => {});
+    w.watch(c);
+    expect(w.getPending()).toEqual([]);
+    s.set(5);
+    const pending = w.getPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toBe(c);
+    w.dispose();
+  });
+
+  it("re-watching the same signal is idempotent", () => {
+    const s = signal(0);
+    let calls = 0;
+    const w = watcher(() => calls++);
+    w.watch(s);
+    w.watch(s);
+    s.set(1);
+    expect(calls).toBe(1);
+    w.dispose();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marjoram",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Widget SDK toolkit — reactive state, template binding, and DOM isolation in under 5KB with zero dependencies",
   "keywords": [
     "dom",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,16 @@ export { useViewModel } from "./useViewModel";
 export * from "./widget/createWidget";
 export { createWidget } from "./widget/createWidget";
 
-export { signal, computed, effect, batch, untracked } from "./reactivity";
-export type { Signal, ReadonlySignal } from "./reactivity";
+export {
+  signal,
+  computed,
+  effect,
+  batch,
+  untracked,
+  watcher,
+  Signal,
+} from "./reactivity";
+export type { ReadonlySignal, SignalOptions, Watcher } from "./reactivity";
 
 export {
   store,

--- a/src/reactivity/index.ts
+++ b/src/reactivity/index.ts
@@ -1,5 +1,13 @@
-export { signal, computed, effect, batch, untracked } from "./signal";
-export type { Signal, ReadonlySignal } from "./signal";
+export {
+  signal,
+  computed,
+  effect,
+  batch,
+  untracked,
+  watcher,
+  Signal,
+} from "./signal";
+export type { ReadonlySignal, SignalOptions, Watcher } from "./signal";
 
 export { store, markRaw, isStore, unwrap, snapshot, subscribe } from "./store";
 export type { Store, Path, PathValue } from "./store";

--- a/src/reactivity/signal.ts
+++ b/src/reactivity/signal.ts
@@ -1,19 +1,49 @@
 // ---------------------------------------------------------------------------
 // Fine-grained reactive signal system with automatic dependency tracking.
 //
-// Three primitives:
-//   signal(value)   — writable reactive value
-//   computed(fn)    — read-only derived value, auto-tracks dependencies
-//   effect(fn)      — side-effect that re-runs when dependencies change
+// Primitives:
+//   signal(value, options?)   — writable reactive value
+//   computed(fn, options?)    — read-only derived value, auto-tracks
+//   effect(fn)                — side-effect that re-runs on dependency change
+//   batch(fn)                 — defer notifications until the callback completes
+//   untracked(fn)             — read signals without subscribing
+//   watcher(notify)           — TC39-shaped low-level observer
 //
-// Dependency tracking uses a global stack: when a computed or effect reads
-// a signal, the signal records that subscriber. On write, only the signals
-// that were actually read are notified — no brute-force re-evaluation.
+// Memoization is epoch/version-based: every node carries a monotonic
+// `_version` bumped only on actual value change. Subscribers record the
+// last-seen version of each source; on read or microtask re-entry they
+// skip work when nothing actually moved. Push-based notification drives
+// scheduling — versions gate the work that follows.
+//
+// Live-watcher count: each node carries `_watcherCount`, transitively
+// propagated from effects/watchers through computeds. A computed only
+// contributes +1 to its sources while its own watcherCount > 0 — that's
+// the distinction store() needs for lazy [watched]/[unwatched] hooks.
+//
+// Spec alignment: the TC39 Signals proposal's `Signal.subtle.watched` /
+// `Signal.subtle.unwatched` symbols, equality customization, Watcher class,
+// and introspection are all exposed via the `Signal` namespace exported
+// from this module. The callable form (`s()`/`s.set(v)`) is the documented
+// DX surface; `.get()`/`.set()` are spec-shaped aliases.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Lifecycle symbols — keyed options that fire on `_watcherCount` 0↔1
+// transitions. Exposed publicly as `Signal.subtle.watched/unwatched`.
+// ---------------------------------------------------------------------------
+
+const WATCHED = Symbol("Signal.subtle.watched");
+const UNWATCHED = Symbol("Signal.subtle.unwatched");
+
+// ---------------------------------------------------------------------------
+// Public types
 // ---------------------------------------------------------------------------
 
 export interface Signal<T = unknown> {
   /** Read the current value (and track the caller as a subscriber). */
   (): T;
+  /** Read the current value (and track the caller). Alias for the callable. */
+  get(): T;
   /** Write a new value, notifying subscribers. */
   set(value: T): void;
   /** Read without tracking (for use outside reactive contexts). */
@@ -25,38 +55,120 @@ export interface Signal<T = unknown> {
 export interface ReadonlySignal<T = unknown> {
   /** Read the current value (and track the caller as a subscriber). */
   (): T;
+  /** Read the current value (and track the caller). Alias for the callable. */
+  get(): T;
   /** Read without tracking. */
   peek(): T;
   /** Remove all subscribers and stop tracking dependencies. */
   dispose(): void;
 }
 
+/**
+ * Per-signal configuration, modeled on `SignalOptions` from the TC39 Signals
+ * proposal. Optional on both `signal()` and `computed()`.
+ *
+ * - `equals` — overrides `Object.is` when deciding whether a write/recompute
+ *   actually changed the value. Returning `true` suppresses notification.
+ * - `[Signal.subtle.watched]` — fires the first time the signal gains a live
+ *   downstream consumer.
+ * - `[Signal.subtle.unwatched]` — fires when the last live consumer goes away.
+ *
+ * Hook callbacks must not read or write signals — same contract as a Watcher
+ * notify callback (enforced in dev builds).
+ */
+export interface SignalOptions<T = unknown> {
+  equals?: (oldValue: T, newValue: T) => boolean;
+  [WATCHED]?: () => void;
+  [UNWATCHED]?: () => void;
+}
+
+/**
+ * Low-level synchronous observer, modeled on `Signal.subtle.Watcher` from
+ * the TC39 Signals proposal. `notify` fires synchronously when a watched
+ * signal becomes stale. The callback must not read or write signals —
+ * dev-mode builds throw if it tries.
+ *
+ * Use it to build custom schedulers; for everyday side effects, use
+ * `effect()`, which internally builds on this primitive.
+ */
+export interface Watcher {
+  watch(...signals: (Signal<unknown> | ReadonlySignal<unknown>)[]): void;
+  unwatch(...signals: (Signal<unknown> | ReadonlySignal<unknown>)[]): void;
+  /** The watched signals that currently have a newer version than last seen. */
+  getPending(): (Signal<unknown> | ReadonlySignal<unknown>)[];
+  dispose(): void;
+}
+
 // ---------------------------------------------------------------------------
-// Subscriber tracking
+// Internal types
 // ---------------------------------------------------------------------------
 
 interface Subscriber {
-  /** Signals this subscriber depends on. */
   _sources: Set<SignalNode>;
-  /** Called when a dependency changes. */
+  _lastSeen: Map<SignalNode, number>;
   _notify(): void;
-  /** Whether this subscriber is currently computing/running. */
   _running: boolean;
+  /** True for computed subscribers — gates watcher-count contribution. */
+  _isComputed?: boolean;
+  /**
+   * True for effects and watchers — leaf consumers that always contribute
+   * +1 to their sources. Computeds contribute only when their own node has
+   * `_watcherCount > 0`.
+   */
+  _isLiveConsumer?: boolean;
+  /** Back-pointer to the SignalNode this subscriber drives (computeds only). */
+  _node?: SignalNode;
 }
 
 /** @internal */
 export interface SignalNode<T = unknown> {
   _value: T;
+  _version: number;
   _subscribers: Set<Subscriber>;
+  _watcherCount: number;
+  /** Computed-only: refresh `_version` if anything moved. */
+  _refresh?: () => void;
+  /** Back-pointer to the subscriber that drives this node (computed only). */
+  _sub?: Subscriber;
+  /**
+   * Custom equality, defaults to Object.is. Internally typed as
+   * `(unknown, unknown)` so SignalNode<T> remains assignable to
+   * SignalNode<unknown> across the registry maps; signal()/computed()
+   * cast at assignment, never invoke equals with foreign values.
+   */
+  _equals?: (oldValue: unknown, newValue: unknown) => boolean;
+  /** Fires on `_watcherCount` 0 → 1 transition. */
+  _onWatched?: () => void;
+  /** Fires on `_watcherCount` 1 → 0 transition. */
+  _onUnwatched?: () => void;
 }
 
-/** Stack of the currently evaluating subscriber (computed or effect). */
-let activeSubscriber: Subscriber | null = null;
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
 
-/** Batch depth counter. When > 0, notifications are deferred. */
+const nodeRegistry = new WeakMap<
+  Signal<unknown> | ReadonlySignal<unknown>,
+  SignalNode
+>();
+const watcherRegistry = new WeakMap<Watcher, Subscriber>();
+const nodeToPublic = new WeakMap<
+  SignalNode,
+  Signal<unknown> | ReadonlySignal<unknown>
+>();
+const subToWatcher = new WeakMap<Subscriber, Watcher>();
+
+let activeSubscriber: Subscriber | null = null;
 let batchDepth = 0;
-/** Set of subscribers that need notification when batch completes. */
 const pendingNotifications = new Set<Subscriber>();
+
+/**
+ * Dev-mode guard: while true, signal reads and writes throw. The Watcher
+ * notify callback and `[watched]`/`[unwatched]` hooks run under this guard
+ * so spec-forbidden I/O surfaces loudly instead of silently corrupting
+ * graph state.
+ */
+let inFrozenCallback = false;
 
 function flushPending(): void {
   const subscribers = [...pendingNotifications];
@@ -66,13 +178,14 @@ function flushPending(): void {
   }
 }
 
-/**
- * Notify subscribers synchronously. Computed signals just mark themselves dirty
- * (a cheap boolean flip). DOM-level batching is handled by SchemaProp.update()
- * which uses queueMicrotask independently.
- */
 function notifySubscribers(node: SignalNode): void {
-  for (const sub of node._subscribers) {
+  // Snapshot before iterating: a downstream `_notify` can synchronously
+  // refresh a computed source, which clears and re-tracks its source set,
+  // re-inserting subscribers into `node._subscribers` mid-iteration. JS
+  // Set iteration visits re-added entries again, which would fire the
+  // same subscriber's notify twice for one upstream change.
+  const subs = [...node._subscribers];
+  for (const sub of subs) {
     if (sub._running) continue; // prevent cycles
     if (batchDepth > 0) {
       pendingNotifications.add(sub);
@@ -83,36 +196,124 @@ function notifySubscribers(node: SignalNode): void {
 }
 
 // ---------------------------------------------------------------------------
+// Watcher-count propagation
+//
+// Counts cross 0↔1 trigger propagation (and fire lifecycle hooks). Crossings
+// within (1, ∞) are pure bookkeeping. A computed's contribution to each
+// source is binary (+1 if live, 0 if dormant), regardless of how many
+// watchers it carries downstream.
+// ---------------------------------------------------------------------------
+
+function runFrozenCallback(fn: () => void): void {
+  const prevActive = activeSubscriber;
+  activeSubscriber = null;
+  const prevFlag = inFrozenCallback;
+  if (process.env.NODE_ENV !== "production") inFrozenCallback = true;
+  try {
+    fn();
+  } finally {
+    if (process.env.NODE_ENV !== "production") inFrozenCallback = prevFlag;
+    activeSubscriber = prevActive;
+  }
+}
+
+function adjustWatcherCount(node: SignalNode, delta: 1 | -1): void {
+  const before = node._watcherCount;
+  node._watcherCount += delta;
+  const after = node._watcherCount;
+
+  if (before === 0 && after === 1) {
+    if (node._sub) {
+      for (const source of node._sub._sources) {
+        adjustWatcherCount(source, 1);
+      }
+    }
+    if (node._onWatched) runFrozenCallback(node._onWatched);
+  } else if (before === 1 && after === 0) {
+    if (node._sub) {
+      for (const source of node._sub._sources) {
+        adjustWatcherCount(source, -1);
+      }
+    }
+    if (node._onUnwatched) runFrozenCallback(node._onUnwatched);
+  }
+}
+
+function contributesWatch(sub: Subscriber): boolean {
+  if (sub._isLiveConsumer) return true;
+  if (sub._node) return sub._node._watcherCount > 0;
+  return false;
+}
+
+function trackDependency(node: SignalNode): void {
+  const sub = activeSubscriber;
+  if (!sub) return;
+  if (sub._sources.has(node)) return;
+  node._subscribers.add(sub);
+  sub._sources.add(node);
+  if (contributesWatch(sub)) {
+    adjustWatcherCount(node, 1);
+  }
+}
+
+function assertNotFrozen(op: "read" | "write"): void {
+  if (process.env.NODE_ENV === "production") return;
+  if (inFrozenCallback) {
+    throw new Error(
+      `[marjoram] Cannot ${op} a signal inside a Watcher notify or [watched]/[unwatched] callback.`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // signal() — writable reactive value
 // ---------------------------------------------------------------------------
 
-export function signal<T>(initialValue: T): Signal<T> {
+export function signal<T>(
+  initialValue: T,
+  options?: SignalOptions<T>
+): Signal<T> {
   const node: SignalNode<T> = {
     _value: initialValue,
+    _version: 0,
     _subscribers: new Set(),
+    _watcherCount: 0,
+    _equals: options?.equals as
+      | ((a: unknown, b: unknown) => boolean)
+      | undefined,
+    _onWatched: options?.[WATCHED],
+    _onUnwatched: options?.[UNWATCHED],
   };
 
-  // Read: track dependency
   const read = (): T => {
-    if (activeSubscriber) {
-      node._subscribers.add(activeSubscriber);
-      activeSubscriber._sources.add(node);
-    }
+    assertNotFrozen("read");
+    trackDependency(node);
     return node._value;
   };
 
-  read.set = (value: T): void => {
-    if (Object.is(node._value, value)) return;
+  const setValue = (value: T): void => {
+    assertNotFrozen("write");
+    const equal = node._equals
+      ? node._equals(node._value, value)
+      : Object.is(node._value, value);
+    if (equal) return;
     node._value = value;
+    node._version++;
     notifySubscribers(node);
   };
 
+  read.get = read;
+  read.set = setValue;
   read.peek = (): T => node._value;
-
   read.dispose = (): void => {
+    for (const sub of node._subscribers) {
+      if (contributesWatch(sub)) adjustWatcherCount(node, -1);
+    }
     node._subscribers.clear();
   };
 
+  nodeRegistry.set(read as Signal<T>, node);
+  nodeToPublic.set(node, read as Signal<T>);
   return read as Signal<T>;
 }
 
@@ -120,78 +321,152 @@ export function signal<T>(initialValue: T): Signal<T> {
 // computed() — derived reactive value with auto-tracking
 // ---------------------------------------------------------------------------
 
-export function computed<T>(fn: () => T): ReadonlySignal<T> {
+export function computed<T>(
+  fn: () => T,
+  options?: SignalOptions<T>
+): ReadonlySignal<T> {
   const node: SignalNode<T> = {
     _value: undefined as T,
+    _version: 0,
     _subscribers: new Set(),
+    _watcherCount: 0,
+    _equals: options?.equals as
+      | ((a: unknown, b: unknown) => boolean)
+      | undefined,
+    _onWatched: options?.[WATCHED],
+    _onUnwatched: options?.[UNWATCHED],
   };
 
   let dirty = true;
+  let initialized = false;
 
   const sub: Subscriber = {
     _sources: new Set(),
+    _lastSeen: new Map(),
     _running: false,
+    _isComputed: true,
+    _node: node,
     _notify() {
       if (!dirty) {
         dirty = true;
-        // Propagate to downstream subscribers
         notifySubscribers(node);
       }
     },
   };
+  node._sub = sub;
 
-  function recompute(): T {
-    // Unsubscribe from old sources
-    for (const source of sub._sources) {
+  function clearSources(): void {
+    const wasLive = node._watcherCount > 0;
+    // Snapshot then atomically clear `sub` bookkeeping so a throwing
+    // [unwatched] hook (via adjustWatcherCount) doesn't leave the
+    // subscriber half-detached from its sources.
+    const sources = [...sub._sources];
+    sub._sources.clear();
+    sub._lastSeen.clear();
+    for (const source of sources) {
       source._subscribers.delete(sub);
     }
-    sub._sources.clear();
+    if (wasLive) {
+      for (const source of sources) {
+        adjustWatcherCount(source, -1);
+      }
+    }
+  }
 
-    // Track new dependencies
+  function recompute(): T {
+    if (initialized) {
+      let stale = false;
+      for (const source of sub._sources) {
+        source._refresh?.();
+        if (source._version !== sub._lastSeen.get(source)) {
+          stale = true;
+          break;
+        }
+      }
+      if (!stale) {
+        dirty = false;
+        return node._value;
+      }
+    }
+
+    clearSources();
+
     const prevSubscriber = activeSubscriber;
     activeSubscriber = sub;
     sub._running = true;
+    let newValue: T;
     try {
-      node._value = fn();
+      newValue = fn();
     } finally {
       sub._running = false;
       activeSubscriber = prevSubscriber;
     }
+
+    for (const source of sub._sources) {
+      sub._lastSeen.set(source, source._version);
+    }
+
+    const equal =
+      initialized &&
+      (node._equals
+        ? node._equals(node._value, newValue)
+        : Object.is(node._value, newValue));
+    if (!equal) {
+      node._value = newValue;
+      node._version++;
+    }
+
+    initialized = true;
     dirty = false;
     return node._value;
   }
 
-  // Eager initial computation to register dependencies
-  recompute();
+  node._refresh = (): void => {
+    if (dirty) recompute();
+  };
 
   const read = (): T => {
-    if (dirty) recompute();
-    if (activeSubscriber) {
-      node._subscribers.add(activeSubscriber);
-      activeSubscriber._sources.add(node);
+    assertNotFrozen("read");
+    if (sub._running) {
+      throw new Error(
+        "[marjoram] Cycle detected: a computed signal cannot read itself during evaluation."
+      );
     }
+    if (dirty) recompute();
+    trackDependency(node);
     return node._value;
   };
 
+  read.get = read;
   read.peek = (): T => {
     if (dirty) recompute();
     return node._value;
   };
-
   read.dispose = (): void => {
-    for (const source of sub._sources) {
-      source._subscribers.delete(sub);
+    clearSources();
+    for (const downstream of node._subscribers) {
+      if (contributesWatch(downstream)) adjustWatcherCount(node, -1);
     }
-    sub._sources.clear();
     node._subscribers.clear();
+    node._refresh = undefined;
     dirty = false;
   };
+
+  // Register before the initial recompute so `Signal.subtle.currentComputed()`
+  // resolves to this callable on the first evaluation.
+  nodeRegistry.set(read as ReadonlySignal<T>, node);
+  nodeToPublic.set(node, read as ReadonlySignal<T>);
+
+  recompute();
 
   return read as ReadonlySignal<T>;
 }
 
 // ---------------------------------------------------------------------------
 // effect() — side-effect that re-runs when dependencies change
+//
+// An effect is a live consumer: it always contributes +1 to each source's
+// watcher count, so transitive [watched]/[unwatched] hooks fire correctly.
 // ---------------------------------------------------------------------------
 
 export function effect(fn: () => void | (() => void)): () => void {
@@ -201,30 +476,48 @@ export function effect(fn: () => void | (() => void)): () => void {
 
   const sub: Subscriber = {
     _sources: new Set(),
+    _lastSeen: new Map(),
     _running: false,
+    _isLiveConsumer: true,
     _notify() {
-      // Defer re-execution to microtask to prevent synchronous recursion
       if (!scheduled && !disposed) {
         scheduled = true;
         queueMicrotask(() => {
           scheduled = false;
-          if (!disposed) run();
+          if (disposed) return;
+          let stale = false;
+          for (const source of sub._sources) {
+            source._refresh?.();
+            if (source._version !== sub._lastSeen.get(source)) {
+              stale = true;
+              break;
+            }
+          }
+          if (stale) run();
         });
       }
     },
   };
 
-  function run(): void {
-    // Run cleanup from previous execution
-    if (typeof cleanup === "function") cleanup();
-
-    // Unsubscribe from old sources
-    for (const source of sub._sources) {
+  function clearSources(): void {
+    // Snapshot then atomically clear `sub` bookkeeping — same rationale as
+    // computed.clearSources: throwing hooks shouldn't leave a half-detached
+    // subscriber.
+    const sources = [...sub._sources];
+    sub._sources.clear();
+    sub._lastSeen.clear();
+    for (const source of sources) {
       source._subscribers.delete(sub);
     }
-    sub._sources.clear();
+    for (const source of sources) {
+      adjustWatcherCount(source, -1);
+    }
+  }
 
-    // Track new dependencies
+  function run(): void {
+    if (typeof cleanup === "function") cleanup();
+    clearSources();
+
     const prevSubscriber = activeSubscriber;
     activeSubscriber = sub;
     sub._running = true;
@@ -234,24 +527,24 @@ export function effect(fn: () => void | (() => void)): () => void {
       sub._running = false;
       activeSubscriber = prevSubscriber;
     }
+
+    for (const source of sub._sources) {
+      sub._lastSeen.set(source, source._version);
+    }
   }
 
-  // Run immediately to establish initial subscriptions
   run();
 
-  // Return a dispose function
   return () => {
+    if (disposed) return;
     disposed = true;
     if (typeof cleanup === "function") cleanup();
-    for (const source of sub._sources) {
-      source._subscribers.delete(sub);
-    }
-    sub._sources.clear();
+    clearSources();
   };
 }
 
 // ---------------------------------------------------------------------------
-// batch() — defer notifications until callback completes
+// batch() / untracked()
 // ---------------------------------------------------------------------------
 
 export function batch(fn: () => void): void {
@@ -260,15 +553,9 @@ export function batch(fn: () => void): void {
     fn();
   } finally {
     batchDepth--;
-    if (batchDepth === 0) {
-      flushPending();
-    }
+    if (batchDepth === 0) flushPending();
   }
 }
-
-// ---------------------------------------------------------------------------
-// untracked() — read signals without creating subscriptions
-// ---------------------------------------------------------------------------
 
 export function untracked<T>(fn: () => T): T {
   const prev = activeSubscriber;
@@ -281,33 +568,230 @@ export function untracked<T>(fn: () => T): T {
 }
 
 // ---------------------------------------------------------------------------
-// Internal building blocks for store() (Phase 2 of the deep-reactivity work).
-//
-// These are NOT public API — they're not re-exported from src/index.ts and are
-// marked @internal. The store implementation in ./store.ts uses them to
-// register and notify per-path signal nodes without duplicating the
-// subscriber-tracking machinery above.
+// watcher() — low-level synchronous observer (TC39 Signal.subtle.Watcher
+// shape). For custom schedulers and framework authors; effect() is the
+// ergonomic choice for everyday work.
 // ---------------------------------------------------------------------------
 
-/** @internal Whether the read happens inside a tracked context (computed/effect/etc). */
-export function _isTracking(): boolean {
+export function watcher(notify: () => void): Watcher {
+  const watched: Array<{
+    pub: Signal<unknown> | ReadonlySignal<unknown>;
+    node: SignalNode;
+  }> = [];
+
+  const sub: Subscriber = {
+    _sources: new Set(),
+    _lastSeen: new Map(),
+    _running: false,
+    _isLiveConsumer: true,
+    _notify() {
+      for (const source of sub._sources) source._refresh?.();
+      let moved = false;
+      for (const source of sub._sources) {
+        if (source._version !== sub._lastSeen.get(source)) {
+          moved = true;
+          break;
+        }
+      }
+      if (!moved) return;
+
+      sub._running = true;
+      try {
+        runFrozenCallback(notify);
+      } finally {
+        sub._running = false;
+      }
+    },
+  };
+
+  function nodeOf(
+    s: Signal<unknown> | ReadonlySignal<unknown>
+  ): SignalNode | undefined {
+    return nodeRegistry.get(s);
+  }
+
+  const w: Watcher = {
+    watch(...signals): void {
+      for (const s of signals) {
+        const node = nodeOf(s);
+        if (!node) {
+          throw new Error(
+            "[marjoram] watcher.watch() received a value that is not a signal or computed."
+          );
+        }
+        if (sub._sources.has(node)) continue;
+        node._subscribers.add(sub);
+        sub._sources.add(node);
+        node._refresh?.();
+        sub._lastSeen.set(node, node._version);
+        watched.push({ pub: s, node });
+        adjustWatcherCount(node, 1);
+      }
+    },
+    unwatch(...signals): void {
+      for (const s of signals) {
+        const node = nodeOf(s);
+        if (!node || !sub._sources.has(node)) continue;
+        node._subscribers.delete(sub);
+        sub._sources.delete(node);
+        sub._lastSeen.delete(node);
+        const idx = watched.findIndex(x => x.node === node);
+        if (idx >= 0) watched.splice(idx, 1);
+        adjustWatcherCount(node, -1);
+      }
+    },
+    getPending(): (Signal<unknown> | ReadonlySignal<unknown>)[] {
+      const pending: (Signal<unknown> | ReadonlySignal<unknown>)[] = [];
+      for (const { pub, node } of watched) {
+        node._refresh?.();
+        if (node._version !== sub._lastSeen.get(node)) {
+          pending.push(pub);
+        }
+      }
+      return pending;
+    },
+    dispose(): void {
+      for (const source of sub._sources) {
+        source._subscribers.delete(sub);
+        adjustWatcherCount(source, -1);
+      }
+      sub._sources.clear();
+      sub._lastSeen.clear();
+      watched.length = 0;
+    },
+  };
+
+  watcherRegistry.set(w, sub);
+  subToWatcher.set(sub, w);
+  return w;
+}
+
+// ---------------------------------------------------------------------------
+// Signal.subtle — spec-shaped namespace for advanced introspection and the
+// `[watched]`/`[unwatched]` lifecycle symbols.
+//
+// Mirrors `Signal.subtle.*` from the TC39 Signals proposal. The callable
+// `signal()`/`computed()` forms remain the primary DX surface; this
+// namespace exists for spec parity and interop with `signal-utils` and
+// other code written against the proposal.
+// ---------------------------------------------------------------------------
+
+function currentComputed(): ReadonlySignal<unknown> | null {
+  if (!activeSubscriber || !activeSubscriber._node) return null;
+  const pub = nodeToPublic.get(activeSubscriber._node);
+  return (pub as ReadonlySignal<unknown>) ?? null;
+}
+
+/**
+ * Whether reads are currently being tracked — true inside any `computed`,
+ * `effect`, or `watcher` evaluation. A small extension to the TC39 surface
+ * that lets reactive containers (like `store()`) preserve "untracked reads
+ * allocate nothing" without poking at private state.
+ */
+function isTracking(): boolean {
   return activeSubscriber !== null;
 }
 
-/** @internal Create a fresh node. The `_value` is unused by stores (raw[key] is the source of truth) but kept consistent with signal() shape. */
-export function _createNode<T>(value: T): SignalNode<T> {
-  return { _value: value, _subscribers: new Set() };
+type Source = Signal<unknown> | ReadonlySignal<unknown>;
+type Sink = ReadonlySignal<unknown> | Watcher;
+
+function subOfTarget(
+  target: ReadonlySignal<unknown> | Watcher
+): Subscriber | undefined {
+  const node = nodeRegistry.get(target as ReadonlySignal<unknown>);
+  if (node && node._sub) return node._sub;
+  return watcherRegistry.get(target as Watcher);
 }
 
-/** @internal Register the active subscriber (if any) as a dependent of this node. */
-export function _track(node: SignalNode): void {
-  if (activeSubscriber) {
-    node._subscribers.add(activeSubscriber);
-    activeSubscriber._sources.add(node);
+function introspectSources(target: ReadonlySignal<unknown> | Watcher): Source[] {
+  const sub = subOfTarget(target);
+  if (!sub) return [];
+  const out: Source[] = [];
+  for (const node of sub._sources) {
+    const pub = nodeToPublic.get(node);
+    if (pub) out.push(pub);
   }
+  return out;
 }
 
-/** @internal Notify subscribers, respecting the existing batch. */
-export function _notify(node: SignalNode): void {
-  notifySubscribers(node);
+function introspectSinks(target: Signal<unknown> | ReadonlySignal<unknown>): Sink[] {
+  const node = nodeRegistry.get(target);
+  if (!node) return [];
+  const out: Sink[] = [];
+  for (const sub of node._subscribers) {
+    if (sub._node) {
+      const pub = nodeToPublic.get(sub._node);
+      if (pub) out.push(pub as ReadonlySignal<unknown>);
+    } else {
+      const w = subToWatcher.get(sub);
+      if (w) out.push(w);
+    }
+  }
+  return out;
 }
+
+function hasSources(target: ReadonlySignal<unknown> | Watcher): boolean {
+  const sub = subOfTarget(target);
+  return !!sub && sub._sources.size > 0;
+}
+
+/**
+ * Spec-shaped: true iff `introspectSinks(target).length > 0` — does any
+ * Computed or Watcher observe this signal. Effect-only observation returns
+ * false (effects are not first-class spec entities); use `hasObservers` to
+ * include effects.
+ */
+function hasSinks(target: Signal<unknown> | ReadonlySignal<unknown>): boolean {
+  const node = nodeRegistry.get(target);
+  if (!node) return false;
+  for (const sub of node._subscribers) {
+    if (sub._node && nodeToPublic.has(sub._node)) return true;
+    if (subToWatcher.has(sub)) return true;
+  }
+  return false;
+}
+
+/**
+ * Marjoram extension: true if ANY observer (computed, watcher, OR effect)
+ * is subscribed to this signal. Used by `store()` to decide whether to
+ * reclaim a per-path slot in its `[unwatched]` hook.
+ */
+function hasObservers(
+  target: Signal<unknown> | ReadonlySignal<unknown>
+): boolean {
+  const node = nodeRegistry.get(target);
+  return !!node && node._subscribers.size > 0;
+}
+
+/**
+ * Spec-shaped namespace, modeled on `Signal.subtle.*` from the TC39 Signals
+ * proposal. Exposes lifecycle symbols and introspection helpers.
+ *
+ * - `Signal.subtle.watched` / `Signal.subtle.unwatched` — option keys passed
+ *   to `signal()`/`computed()` to subscribe to live-watcher transitions.
+ * - `Signal.subtle.untrack(fn)` — alias for `untracked()`.
+ * - `Signal.subtle.currentComputed()` — the computed currently being
+ *   evaluated, or `null` if not inside one.
+ * - `Signal.subtle.introspectSources(target)` — sources of a computed or watcher.
+ * - `Signal.subtle.introspectSinks(target)` — downstream subscribers of a signal/computed.
+ * - `Signal.subtle.hasSources(target)` / `hasSinks(target)` — boolean shortcuts.
+ */
+export const Signal = {
+  subtle: {
+    watched: WATCHED,
+    unwatched: UNWATCHED,
+    untrack: untracked,
+    currentComputed,
+    introspectSources,
+    introspectSinks,
+    hasSources,
+    hasSinks,
+    hasObservers,
+    isTracking,
+  },
+} as const;
+
+// The internal escape hatches `_isTracking`/`_createNode`/`_track`/`_notify`
+// that earlier versions exposed to store() have been removed: store() now
+// builds on the public signal() primitive plus the `Signal.subtle` surface.
+// If you need "am I in a reactive context?" use `Signal.subtle.isTracking()`.

--- a/src/reactivity/store.ts
+++ b/src/reactivity/store.ts
@@ -1,21 +1,26 @@
 // ---------------------------------------------------------------------------
 // store() — deep reactivity primitive.
 //
-// Peer to signal(): where signal() is shallow and reference-based, store() is
-// deep and path-granular. Mutating state.user.address.city = "x" notifies only
-// subscribers to that exact path. Built on the same SignalNode + Subscriber
-// machinery as signal() — no parallel reactivity system.
+// Peer to signal(): where signal() is shallow and reference-based, store()
+// is deep and path-granular. Mutating state.user.address.city = "x"
+// notifies only subscribers to that exact path.
+//
+// Implementation note (v1.2): every per-path tracking node is a real
+// `signal()` carrying `equals: () => false` and `[Signal.subtle.unwatched]`
+// for lazy GC. No internal escape hatches into reactivity — the entire
+// deep-reactivity surface is built from the public primitives that the
+// TC39 Signals proposal defines (plus the small `Signal.subtle.isTracking`
+// extension). This doubles as a worked example that the spec primitives
+// are sufficient for deep reactivity.
 //
 // Design contract: docs/STORES.md.
 // Patterns verified against competitor source: docs/STORE_RESEARCH_FINDINGS.md.
 // ---------------------------------------------------------------------------
 
 import {
-  type SignalNode,
-  _isTracking,
-  _createNode,
-  _track,
-  _notify,
+  signal,
+  type Signal as SignalCallable,
+  Signal,
   batch,
   effect as signalEffect,
   untracked,
@@ -99,10 +104,18 @@ function shouldProxy(value: unknown): value is object {
 }
 
 // ---------------------------------------------------------------------------
-// Per-raw-object SignalNode map. Created lazily, on first tracked read.
+// Per-raw-object signal map. Created lazily, on first tracked read.
+//
+// Each entry is a real `signal(undefined, { equals: () => false, [unwatched]: ... })`:
+//   - value is unused (raw[key] is the source of truth)
+//   - equals: () => false makes every .set(undefined) a real notification
+//   - [unwatched] GCs the entry when the last live consumer disconnects,
+//     but only if no non-live consumers (computeds without watchers) are
+//     still referencing it.
 // ---------------------------------------------------------------------------
 
-type NodeMap = Record<PropertyKey, SignalNode>;
+type PathSignal = SignalCallable<undefined>;
+type NodeMap = Record<PropertyKey, PathSignal>;
 
 function getOrCreateNodeMap(raw: object): NodeMap {
   let nodes = (raw as Record<symbol, unknown>)[$NODE] as NodeMap | undefined;
@@ -118,19 +131,35 @@ function getOrCreateNodeMap(raw: object): NodeMap {
   return nodes;
 }
 
+function ensurePathSignal(nodes: NodeMap, key: PropertyKey): PathSignal {
+  let s = nodes[key];
+  if (!s) {
+    // Holds undefined forever; what matters is the version bump on each .set.
+    const created: PathSignal = signal<undefined>(undefined, {
+      equals: () => false,
+      [Signal.subtle.unwatched]: () => {
+        // Reclaim the slot only when no readers remain at all — a non-live
+        // computed reader (no downstream watcher) still needs the same
+        // signal identity to be notified when the path changes later.
+        // hasObservers (Marjoram extension) counts ANY subscriber type,
+        // including effects; the spec-shaped `hasSinks` would miss those.
+        if (!Signal.subtle.hasObservers(created)) delete nodes[key];
+      },
+    });
+    s = created;
+    nodes[key] = s;
+  }
+  return s;
+}
+
 /**
  * Subscribe the active reactive context (if any) to raw[key]. No-op outside
  * a tracked context — this is the "reads are free" guarantee.
  */
 function trackPath(raw: object, key: PropertyKey): void {
-  if (!_isTracking()) return;
+  if (!Signal.subtle.isTracking()) return;
   const nodes = getOrCreateNodeMap(raw);
-  let node = nodes[key];
-  if (!node) {
-    node = _createNode(undefined);
-    nodes[key] = node;
-  }
-  _track(node);
+  ensurePathSignal(nodes, key)(); // reading subscribes the active tracker
 }
 
 /**
@@ -139,45 +168,21 @@ function trackPath(raw: object, key: PropertyKey): void {
  * removed.
  */
 function trackKeys(raw: object): void {
-  if (!_isTracking()) return;
+  if (!Signal.subtle.isTracking()) return;
   const nodes = getOrCreateNodeMap(raw);
-  let node = nodes[$KEYS];
-  if (!node) {
-    node = _createNode(undefined);
-    nodes[$KEYS] = node;
-  }
-  _track(node);
+  ensurePathSignal(nodes, $KEYS)();
 }
 
 /** Fire subscribers of raw[key]. No-op if nothing ever tracked it. */
 function notifyPath(raw: object, key: PropertyKey): void {
   const nodes = (raw as Record<symbol, unknown>)[$NODE] as NodeMap | undefined;
-  if (!nodes) return;
-  const node = nodes[key];
-  if (node) _notify(node);
+  nodes?.[key]?.set(undefined);
 }
 
 /** Fire iteration / key-set subscribers. */
 function notifyKeys(raw: object): void {
   const nodes = (raw as Record<symbol, unknown>)[$NODE] as NodeMap | undefined;
-  if (!nodes) return;
-  const node = nodes[$KEYS];
-  if (node) _notify(node);
-}
-
-/**
- * Drop a path's SignalNode from the map. Call AFTER notifyPath so any pending
- * subscribers have already been scheduled — they re-run and re-subscribe to a
- * fresh node, and this orphaned node GCs. Prevents unbounded growth of the
- * $NODE map for stores with churning keys (caches, dynamic maps).
- *
- * For replaced object subtrees no explicit drop is needed: the old raw object
- * carries its own $NODE via a symbol property, so the whole subtree's metadata
- * GCs together with the unreachable old object.
- */
-function dropNode(raw: object, key: PropertyKey): void {
-  const nodes = (raw as Record<symbol, unknown>)[$NODE] as NodeMap | undefined;
-  if (nodes && key in nodes) delete nodes[key];
+  nodes?.[$KEYS]?.set(undefined);
 }
 
 // ---------------------------------------------------------------------------
@@ -290,7 +295,9 @@ const storeHandler: ProxyHandler<object> = {
         if (newLen < oldLength) {
           for (let i = newLen; i < oldLength; i++) {
             notifyPath(raw, String(i));
-            dropNode(raw, String(i)); // removed index — GC its node
+            // GC is handled by [Signal.subtle.unwatched] on the per-path
+            // signal — when subscribers re-run and stop reading these
+            // removed indices, the slot reclaims itself.
           }
           notifyKeys(raw);
         } else if (newLen > oldLength) {
@@ -313,8 +320,7 @@ const storeHandler: ProxyHandler<object> = {
     if (!ok) return false;
     notifyPath(raw, key);
     notifyKeys(raw);
-    // GC the deleted key's node (after notify scheduled its subscribers).
-    dropNode(raw, key);
+    // GC handled by [Signal.subtle.unwatched] on the per-path signal.
     return true;
   },
 


### PR DESCRIPTION
## Summary

Non-breaking additive v1.2. Aligns the reactivity engine with the [TC39 Signals proposal](https://github.com/tc39/proposal-signals) (Stage 1) and rebuilds `store()` on the public primitive surface — no internal escape hatches into reactivity.

## What landed

**Signals**
- Epoch/version memoization replaces the dirty flag; computeds skip recompute when no source moved; effects skip re-runs when an equals-gated computed left its version untouched. Diamond benchmark: perfect 1000-for-1000 dedup.
- New `watcher(notify)` — synchronous `Signal.subtle.Watcher`-shaped primitive with `watch/unwatch/getPending/dispose`. Dev-mode I/O assertion in the `notify` callback.
- `SignalOptions<T>` on `signal()` / `computed()`: `equals`, `[Signal.subtle.watched]`, `[Signal.subtle.unwatched]`. Lifecycle hooks fire on the 0↔1 live-watcher transition with proper transitive propagation (subscriber-count vs watcher-count distinction).
- `.get()` / `.set()` / `.peek()` methods on every callable for spec / `signal-utils` interop. Callable stays primary DX.
- Cycle detection throws (was silent skip).

**`Signal.subtle` namespace**
- `watched`, `unwatched`, `untrack`, `currentComputed`, `introspectSources/Sinks`, `hasSources/Sinks`, plus Marjoram extensions `hasObservers` (includes effects) and `isTracking`.

**`store()` rebuilt on public primitives**
- Per-path tracker is now a real `signal(undefined, { equals: () => false, [unwatched]: ... })`. Slot reclaims itself when the last live consumer disconnects (gated by `hasObservers` so non-live computed readers stay valid).
- Internal `_isTracking/_createNode/_track/_notify` escape hatches deleted from `signal.ts`.

**Adversarial review fixes**
- `notifySubscribers` snapshots before iterating — a downstream `_notify` synchronously refreshing a computed source mutates the parent's subscriber set mid-iteration; JS Set iteration re-visits re-added entries, which fired watcher `notify` twice per upstream change.
- `clearSources` snapshots and atomically clears bookkeeping before firing watcher-count adjustments. A throwing `[unwatched]` hook now leaves the graph in a consistent "no sources" state.
- `hasSinks` aligned with `introspectSinks` (spec-shaped). `hasObservers` added for raw count.

## Bundle impact

UMD gzipped: **5.83 KB → 6.87 KB** (+1.04 KB). Under the project's 7 KB gate.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — 0 errors (49 pre-existing warnings)
- [x] `npm test` — **454/454 pass** (was 416; +38 new across watcher, spec-surface, and adversarial probes)
- [x] `npm run build` — clean
- [x] Bundle size measured: 6.87 KB UMD / 6.76 KB ESM gzipped
- [x] Diamond perf benchmark: perfect 1000-for-1000 dedup

## Honest framing

This lands spec-shape-compatible primitives with lifecycle hooks and a Watcher. It is **not** a pull-based glitch-free evaluation graph (Reactively / alien-signals style); push-based propagation is preserved. "TC39-aligned reference implementation" is defensible; "fastest signals engine in JS" is not, and docs do not claim it.

## Known gaps (deferred, documented)

- `Watcher.getPending()` doesn't auto-clear when the user observes a watched signal via `.get()` — strict-spec behavior needs a read-path hook to update watcher `_lastSeen`. Targeting v1.3.
- Effects aren't first-class spec entities, so they show up in `hasObservers` but not `introspectSinks` / `hasSinks`. Documented in JSDoc.