### PR TITLE
Clarify watcher() spec divergence + GC-strategy study for store()

### DIFF
--- a/__tests__/reactivity/spec-gc-strategies.test.ts
+++ b/__tests__/reactivity/spec-gc-strategies.test.ts
@@ -1,0 +1,287 @@
+// ---------------------------------------------------------------------------
+// Sufficiency study: keyed-cache GC strategies built on the public primitives.
+//
+// store() backs each reached path with `signal(undefined, { equals: () => false })`
+// and reclaims the per-path node in `[unwatched]`. This file pins, using only
+// the public reactivity surface, the facts behind that GC design and the
+// spec-pure alternative described in store.ts's header comment. It doubles as
+// a runnable artifact for the TC39 Signals discussion on `watched`/`unwatched`
+// liveness vs. subscription (tc39/proposal-signals#227).
+//
+// Three things are demonstrated:
+//   1. What is actually subscribed to a per-path node when `[unwatched]` fires
+//      — the operative case is a DORMANT COMPUTED, never a lingering effect.
+//   2. Gating eviction on liveness alone ORPHANS that dormant computed (the
+//      trap a spec-`hasSinks` gate falls into, since spec `hasSinks` is
+//      liveness-gated and excludes unwatched computeds).
+//   3. The spec-pure deferred-notify GC: reclaim promptly on the public
+//      surface alone, at a cost of one spurious recompute per dormant reader.
+// ---------------------------------------------------------------------------
+
+import { signal, computed, effect, Signal } from "../../src/reactivity";
+import type { Signal as SignalCallable } from "../../src/reactivity";
+
+const flush = () => new Promise<void>(resolve => queueMicrotask(() => resolve()));
+
+describe("keyed-cache GC strategies on the public primitives", () => {
+  // -------------------------------------------------------------------------
+  // 1. Introspection at the [unwatched] edge.
+  //
+  // A per-path node fires [unwatched] when its live-watcher count drops to 0.
+  // Question: what can still be subscribed at that instant? Effects are live
+  // consumers — a subscribed effect keeps the count > 0, and effect teardown
+  // removes the effect from the node's subscriber set *before* decrementing to
+  // 0 — so no effect is ever present when [unwatched] fires. The only thing
+  // that can remain is a dormant computed (read the node, no live downstream),
+  // which contributes 0 to the count.
+  // -------------------------------------------------------------------------
+  describe("the [unwatched] edge", () => {
+    it("a dormant computed is still subscribed; an effect is not", () => {
+      const atEdge: Array<{ hasSinks: boolean; hasObservers: boolean }> = [];
+
+      const node: SignalCallable<undefined> = signal<undefined>(undefined, {
+        equals: () => false,
+        [Signal.subtle.unwatched]: () => {
+          atEdge.push({
+            hasSinks: Signal.subtle.hasSinks(node),
+            hasObservers: Signal.subtle.hasObservers(node),
+          });
+        },
+      });
+
+      // Dormant computed reads the node → subscribes, contributes 0 to liveness.
+      const c = computed(() => {
+        node();
+        return 1;
+      });
+      c(); // evaluate so the subscription is established
+
+      // A live effect makes the node live (count 0 → 1), then goes away,
+      // dropping it back to 0 and firing [unwatched].
+      const dispose = effect(() => {
+        node();
+      });
+      dispose();
+
+      expect(atEdge).toHaveLength(1);
+      // hasObservers (any subscriber) sees the dormant computed → store() will
+      // NOT evict, which is correct.
+      expect(atEdge[0].hasObservers).toBe(true);
+      // Marjoram's hasSinks is a non-liveness-gated superset, so it ALSO sees
+      // the dormant computed here. The spec's hasSinks/introspectSinks would
+      // NOT — they include a computed sink only "if that computed signal is
+      // (recursively) watched" — so a spec-hasSinks gate would wrongly report
+      // "no sinks" and evict. That is the trap exercised in section 2.
+      expect(atEdge[0].hasSinks).toBe(true);
+    });
+
+    it("no subscriber remains when the last reader was an effect", () => {
+      const atEdge: Array<{ hasObservers: boolean }> = [];
+
+      const node: SignalCallable<undefined> = signal<undefined>(undefined, {
+        equals: () => false,
+        [Signal.subtle.unwatched]: () => {
+          atEdge.push({ hasObservers: Signal.subtle.hasObservers(node) });
+        },
+      });
+
+      const disposeA = effect(() => {
+        node();
+      });
+      const disposeB = effect(() => {
+        node();
+      });
+      disposeA(); // count 2 → 1, no [unwatched]
+      disposeB(); // count 1 → 0 → [unwatched]; the last effect is already gone
+
+      expect(atEdge).toHaveLength(1);
+      // Confirms effects do not linger at the edge: hasObservers is false, so
+      // the "hasSinks misses effect-only readers" concern cannot arise here —
+      // the operative reason to prefer hasObservers over the SPEC's hasSinks is
+      // the dormant computed of section 1, not a lingering effect.
+      expect(atEdge[0].hasObservers).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Liveness-gated eviction orphans a dormant computed.
+  //
+  // A one-key "store": `box` holds the value, `node` is the invalidation pulse.
+  // read() subscribes the active context; write() notifies. We compare two GC
+  // gates inside [unwatched].
+  // -------------------------------------------------------------------------
+  describe("liveness-gated eviction is unsafe", () => {
+    it("evicting without checking subscribers orphans a dormant computed", async () => {
+      let box = 1;
+      let node: SignalCallable<undefined> | null = null;
+      let evicted = false;
+
+      const ensure = (): SignalCallable<undefined> => {
+        if (!node) {
+          node = signal<undefined>(undefined, {
+            equals: () => false,
+            // LIVENESS-ONLY gate: reclaim as soon as no live watcher remains,
+            // ignoring dormant readers — what a spec-`hasSinks` gate would do.
+            [Signal.subtle.unwatched]: () => {
+              node = null;
+              evicted = true;
+            },
+          });
+        }
+        return node;
+      };
+      const read = (): number => {
+        ensure()();
+        return box;
+      };
+      const write = (v: number): void => {
+        box = v;
+        node?.set(undefined);
+      };
+
+      const c = computed(() => read());
+      expect(c()).toBe(1);
+
+      const dispose = effect(() => {
+        read();
+      });
+      dispose(); // [unwatched] → eviction nulls `node`
+      expect(evicted).toBe(true);
+
+      // The dormant computed memorized the evicted node. write() finds
+      // node === null, notifies nothing, and c is never invalidated.
+      write(2);
+      await flush();
+      expect(c()).toBe(1); // STALE — the orphan bug, pinned.
+    });
+
+    it("the hasObservers gate keeps the node and stays correct", async () => {
+      let box = 1;
+      const make = (): {
+        read: () => number;
+        write: (v: number) => void;
+      } => {
+        let node: SignalCallable<undefined> | null = null;
+        const ensure = (): SignalCallable<undefined> => {
+          if (!node) {
+            const created: SignalCallable<undefined> = signal<undefined>(
+              undefined,
+              {
+                equals: () => false,
+                [Signal.subtle.unwatched]: () => {
+                  // Reclaim only when no subscriber of any kind remains.
+                  if (!Signal.subtle.hasObservers(created)) node = null;
+                },
+              }
+            );
+            node = created;
+          }
+          return node;
+        };
+        return {
+          read: () => {
+            ensure()();
+            return box;
+          },
+          write: (v: number) => {
+            box = v;
+            node?.set(undefined);
+          },
+        };
+      };
+
+      const { read, write } = make();
+      const c = computed(() => read());
+      expect(c()).toBe(1);
+
+      const dispose = effect(() => {
+        read();
+      });
+      dispose(); // [unwatched] fires, but the dormant computed keeps the node alive
+
+      write(2);
+      await flush();
+      expect(c()).toBe(2); // fresh — no orphan.
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Deferred-notify GC — spec-pure, bounded memory, with a measurable cost.
+  //
+  // [unwatched] cannot .set() (frozen-callback rule). So defer: schedule a
+  // microtask, track liveness with the watched/unwatched hooks, and if still
+  // dormant, set(undefined) (now allowed — outside the frozen callback) then
+  // delete the node. A dormant computed is spuriously invalidated and re-links
+  // to a fresh node on its next read. This reclaims promptly using ONLY the
+  // public surface — no hasObservers — at the cost of one extra recompute.
+  // -------------------------------------------------------------------------
+  describe("deferred-notify GC is spec-pure", () => {
+    it("reclaims promptly and costs exactly one spurious recompute", async () => {
+      let box = 1;
+      let node: SignalCallable<undefined> | null = null;
+      let live = false;
+      let reclaimed = false;
+      let recomputes = 0;
+
+      const ensure = (): SignalCallable<undefined> => {
+        if (!node) {
+          const created: SignalCallable<undefined> = signal<undefined>(
+            undefined,
+            {
+              equals: () => false,
+              [Signal.subtle.watched]: () => {
+                live = true;
+              },
+              [Signal.subtle.unwatched]: () => {
+                live = false;
+                queueMicrotask(() => {
+                  if (live) return; // re-armed by a new live reader since
+                  created.set(undefined); // notify dormant readers (not frozen here)
+                  if (node === created) {
+                    node = null;
+                    reclaimed = true;
+                  }
+                });
+              },
+            }
+          );
+          node = created;
+        }
+        return node;
+      };
+      const read = (): number => {
+        ensure()();
+        return box;
+      };
+      const write = (v: number): void => {
+        box = v;
+        node?.set(undefined);
+      };
+
+      const c = computed(() => {
+        recomputes++;
+        return read();
+      });
+      expect(c()).toBe(1);
+      expect(recomputes).toBe(1);
+
+      const dispose = effect(() => {
+        read();
+      });
+      dispose(); // schedules the deferred reclaim
+      await flush();
+
+      // Bounded memory: the slot was reclaimed promptly, no hasObservers needed.
+      expect(reclaimed).toBe(true);
+      // The dormant computed was spuriously invalidated; reading it recomputes
+      // (re-linking to a fresh node) — value unchanged, one extra recompute.
+      expect(c()).toBe(1);
+      expect(recomputes).toBe(2);
+
+      // Correctness preserved: later writes still reach the computed.
+      write(2);
+      await flush();
+      expect(c()).toBe(2);
+    });
+  });
+});

--- a/__tests__/reactivity/watcher.test.ts
+++ b/__tests__/reactivity/watcher.test.ts
@@ -9,6 +9,10 @@ describe("Watcher smoke", () => {
     expect(calls).toBe(0);
     s.set(2);
     expect(calls).toBe(1);
+    // Auto-re-arm: unlike the spec's one-shot Watcher (which would require a
+    // watch() re-arm before firing notify again), Marjoram's notify fires on
+    // every qualifying change. This divergence is intentional — see the
+    // `Watcher` interface doc in src/reactivity/signal.ts.
     s.set(3);
     expect(calls).toBe(2);
     w.dispose();

--- a/src/reactivity/signal.ts
+++ b/src/reactivity/signal.ts
@@ -7,7 +7,7 @@
 //   effect(fn)                — side-effect that re-runs on dependency change
 //   batch(fn)                 — defer notifications until the callback completes
 //   untracked(fn)             — read signals without subscribing
-//   watcher(notify)           — TC39-shaped low-level observer
+//   watcher(notify)           — TC39-shaped observer (notify auto-re-arms)
 //
 // Memoization is epoch/version-based: every node carries a monotonic
 // `_version` bumped only on actual value change. Subscribers record the
@@ -83,13 +83,22 @@ export interface SignalOptions<T = unknown> {
 }
 
 /**
- * Low-level synchronous observer, modeled on `Signal.subtle.Watcher` from
- * the TC39 Signals proposal. `notify` fires synchronously when a watched
- * signal becomes stale. The callback must not read or write signals —
- * dev-mode builds throw if it tries.
+ * Low-level synchronous observer in the shape of `Signal.subtle.Watcher`
+ * from the TC39 Signals proposal: `watch`/`unwatch`/`getPending`/`dispose`,
+ * a `notify` that fires synchronously when a watched signal becomes stale,
+ * and a callback that must not read or write signals (dev-mode builds throw).
  *
- * Use it to build custom schedulers; for everyday side effects, use
- * `effect()`, which internally builds on this primitive.
+ * Deliberate divergence from the spec contract: the spec's `notify` is
+ * *one-shot* — it fires once on the clean→stale transition and stays quiet
+ * until you re-arm via `watch()`. Marjoram's `notify` instead re-arms
+ * automatically and fires on *every* qualifying change (see the smoke test
+ * in `__tests__/reactivity/watcher.test.ts`). It is an "observe all changes"
+ * observer, not a one-shot scheduler hook; consumers porting spec-style code
+ * (notify → drain `getPending()` → `watch()` to re-arm) should know the
+ * explicit re-arm is a no-op here.
+ *
+ * Use it to build custom schedulers. For everyday side effects use `effect()`,
+ * which is an independent primitive — it does NOT build on `watcher()`.
  */
 export interface Watcher {
   watch(...signals: (Signal<unknown> | ReadonlySignal<unknown>)[]): void;
@@ -568,9 +577,11 @@ export function untracked<T>(fn: () => T): T {
 }
 
 // ---------------------------------------------------------------------------
-// watcher() — low-level synchronous observer (TC39 Signal.subtle.Watcher
-// shape). For custom schedulers and framework authors; effect() is the
-// ergonomic choice for everyday work.
+// watcher() — low-level synchronous observer in the `Signal.subtle.Watcher`
+// shape. NOTE: notify auto-re-arms (fires on every qualifying change), unlike
+// the spec's one-shot notify. For custom schedulers and framework authors;
+// effect() is the ergonomic choice for everyday work (and is independent of
+// this primitive).
 // ---------------------------------------------------------------------------
 
 export function watcher(notify: () => void): Watcher {

--- a/src/reactivity/store.ts
+++ b/src/reactivity/store.ts
@@ -7,11 +7,30 @@
 //
 // Implementation note (v1.2): every per-path tracking node is a real
 // `signal()` carrying `equals: () => false` and `[Signal.subtle.unwatched]`
-// for lazy GC. No internal escape hatches into reactivity — the entire
-// deep-reactivity surface is built from the public primitives that the
-// TC39 Signals proposal defines (plus the small `Signal.subtle.isTracking`
-// extension). This doubles as a worked example that the spec primitives
-// are sufficient for deep reactivity.
+// for lazy GC. No reach into private signal state — the deep-reactivity
+// surface is built from the public TC39 Signals primitives, plus two
+// extensions to the public `Signal.subtle` namespace:
+//   - `Signal.subtle.isTracking()` — the tracking predicate (trackPath /
+//     trackKeys) that keeps untracked reads allocation-free.
+//   - `Signal.subtle.hasObservers()` — the GC gate in the `[unwatched]` hook:
+//     reclaim a path slot only when no subscriber of any kind remains. The
+//     spec's `hasSinks` is liveness-gated (it excludes a computed that read the
+//     node but is not itself watched), so a spec-`hasSinks` gate would evict
+//     while a dormant computed still depends on the slot — orphaning it.
+//     Verified in __tests__/reactivity/spec-gc-strategies.test.ts.
+//
+// These buy efficiency, not possibility. Deep, path-granular reactivity with
+// bounded memory under key churn IS expressible on the public primitives
+// alone: `[unwatched]` cannot `.set()` (frozen-callback rule, enforced at
+// signal.ts:259), so a spec-pure store would defer — schedule a microtask,
+// track liveness via the watched/unwatched hooks, and if still dormant
+// `set(undefined)` then delete the node; a dormant computed re-links to a
+// fresh node on its next read. The cost of that variant is one spurious
+// recompute per dormant reader at GC time. `hasObservers` lets store() skip
+// it — reclaim only when truly unreferenced, never disturb a dormant reader.
+// The tradeoff cuts both ways: this strategy waits for the last edge to drop,
+// so an immortal dormant computed can pin a slot, whereas the deferred variant
+// always reclaims promptly. Neither dominates.
 //
 // Design contract: docs/STORES.md.
 // Patterns verified against competitor source: docs/STORE_RESEARCH_FINDINGS.md.
@@ -138,11 +157,16 @@ function ensurePathSignal(nodes: NodeMap, key: PropertyKey): PathSignal {
     const created: PathSignal = signal<undefined>(undefined, {
       equals: () => false,
       [Signal.subtle.unwatched]: () => {
-        // Reclaim the slot only when no readers remain at all — a non-live
-        // computed reader (no downstream watcher) still needs the same
-        // signal identity to be notified when the path changes later.
-        // hasObservers (Marjoram extension) counts ANY subscriber type,
-        // including effects; the spec-shaped `hasSinks` would miss those.
+        // Reclaim the slot only when no subscriber remains at all. At this
+        // edge the remaining subscriber, if any, is always a dormant computed
+        // (read the path, no live downstream) — effects are live consumers and
+        // are removed before [unwatched] fires. That dormant computed still
+        // needs this exact signal identity to be notified when the path changes
+        // later, so eviction here would orphan it. hasObservers counts any
+        // subscriber and sees it. The spec's `hasSinks` is liveness-gated — it
+        // excludes an unwatched computed sink — so a spec-`hasSinks` gate would
+        // evict and orphan the reader (proven in
+        // __tests__/reactivity/spec-gc-strategies.test.ts).
         if (!Signal.subtle.hasObservers(created)) delete nodes[key];
       },
     });


### PR DESCRIPTION
## What changed

Documentation accuracy + a runnable test artifact. **No runtime or bundle impact** — every change is comments or tests.

- **`watcher()` docs** — document that `notify` auto-re-arms (fires on every qualifying change), a deliberate divergence from the spec's one-shot `Signal.subtle.Watcher`. Also drops an inaccurate doc claim that `effect()` builds on `watcher()` (it's independent).
- **`__tests__/reactivity/spec-gc-strategies.test.ts`** (new, 5 tests) — a public-API-only study of per-path GC for `store()`-style deep reactivity, intended as an artifact for [tc39/proposal-signals#227](https://github.com/tc39/proposal-signals/issues/227). It pins:
  - what is subscribed to a per-path node when `[unwatched]` fires (a *dormant computed*, never a lingering effect);
  - that gating eviction on liveness alone **orphans** that dormant computed (the spec-`hasSinks` trap);
  - that the `hasObservers` gate stays correct;
  - that a spec-pure **deferred-notify** GC reclaims promptly at a cost of exactly one spurious recompute per dormant reader.
- **`store()` comment correction** — `hasObservers` is needed over the spec's `hasSinks` because spec `hasSinks` is *liveness-gated* (excludes dormant/unwatched computeds), **not** because it 'ignores effect-only readers' — effects don't linger at the `[unwatched]` edge (now verified by the new test).

## Public-API impact

None. Comments + tests only; no exported symbol or behavior changes.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test` — 459 passing (38 suites), incl. 5 new